### PR TITLE
Readme: add missing `]` to the short option sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can specify short-name to an option using `OptionAttribute`.
 // $ remove --force --recursive
 // $ remove -r -f
 // $ remove -rf
-public void Remove([Option('f')]bool force, [Option('r')bool recursive) { ... }
+public void Remove([Option('f')]bool force, [Option('r')]bool recursive) { ... }
 ```
 
 If a parameter is `T[]` or `IEnumerable<T>`, a command accepts one or more options by the same name.


### PR DESCRIPTION
As described in the title, added a missing `]` to the readme.