### PR TITLE
Moved the lowercasing of commands after overload processing

### DIFF
--- a/src/Cocona.Core/Command/CoconaCommandProvider.cs
+++ b/src/Cocona.Core/Command/CoconaCommandProvider.cs
@@ -119,8 +119,6 @@ namespace Cocona.Command
             var description = commandAttr?.Description ?? string.Empty;
             var aliases = commandAttr?.Aliases ?? Array.Empty<string>();
 
-            if (_enableConvertCommandNameToLowerCase) commandName = ToCommandCase(commandName);
-
             var isPrimaryCommand = primaryCommandAttr != null;
             var isHidden = commandHiddenAttr != null;
 
@@ -253,6 +251,8 @@ namespace Cocona.Command
                     overloadDescriptors[i] = overloadDescriptor;
                 }
             }
+            
+            if (_enableConvertCommandNameToLowerCase) commandName = ToCommandCase(commandName);
 
             var flags = ((isHidden) ? CommandFlags.Hidden : CommandFlags.None) |
                         ((isSingleCommand || isPrimaryCommand) ? CommandFlags.Primary : CommandFlags.None);

--- a/test/Cocona.Test/Command/CommandProvider/CommandOverloadTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CommandOverloadTest.cs
@@ -37,6 +37,17 @@ namespace Cocona.Test.Command.CommandProvider
             var provider = new CoconaCommandProvider(new[] { typeof(TestCommand_Overload_Multiple_UnknownOption) });
             Assert.Throws<CoconaException>(() => provider.GetCommandCollection());
         }
+        
+        [Fact]
+        public void Match_CommandName_LowerCase()
+        {
+            var provider = new CoconaCommandProvider(new[] { typeof(TestCommand_Overload_Single) }, enableConvertCommandNameToLowerCase: true);
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(1);
+            commands.Primary.Should().NotBeNull();
+            commands.Primary.Overloads.Should().HaveCount(2);
+        }
 
         class TestCommand_Overload_Single
         {


### PR DESCRIPTION
Small fix to make sure that the overloads are resolved before we change the case of the command. 

A unit test covering this case should be made but not totally sure how to proceed.