### PR TITLE
Introduce HelpMessageBuilder

### DIFF
--- a/Cocona.sln
+++ b/Cocona.sln
@@ -74,6 +74,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoconaSample.Advanced.Optio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoconaSample.Advanced.CommandMethodForwarding", "samples\Advanced.CommandMethodForwarding\CoconaSample.Advanced.CommandMethodForwarding.csproj", "{2E5BEBF1-FCDE-4DA3-9A06-4EC721E89AFD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.Advanced.HelpOnDemand", "samples\Advanced.HelpOnDemand\CoconaSample.Advanced.HelpOnDemand.csproj", "{089D815D-2199-4CCA-9BAF-F7386F883063}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -188,6 +190,10 @@ Global
 		{2E5BEBF1-FCDE-4DA3-9A06-4EC721E89AFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E5BEBF1-FCDE-4DA3-9A06-4EC721E89AFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E5BEBF1-FCDE-4DA3-9A06-4EC721E89AFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{089D815D-2199-4CCA-9BAF-F7386F883063}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{089D815D-2199-4CCA-9BAF-F7386F883063}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089D815D-2199-4CCA-9BAF-F7386F883063}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{089D815D-2199-4CCA-9BAF-F7386F883063}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -217,6 +223,7 @@ Global
 		{1951CD16-9CFD-4DF1-A0ED-7F4EC6AE4D72} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{974EB617-441F-4DC8-88CE-92C896E0FC58} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{2E5BEBF1-FCDE-4DA3-9A06-4EC721E89AFD} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
+		{089D815D-2199-4CCA-9BAF-F7386F883063} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DBA26EF-235B-4656-A5DD-00C266A42735}

--- a/samples/Advanced.HelpOnDemand/CoconaSample.Advanced.HelpOnDemand.csproj
+++ b/samples/Advanced.HelpOnDemand/CoconaSample.Advanced.HelpOnDemand.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cocona\Cocona.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Advanced.HelpOnDemand/Program.cs
+++ b/samples/Advanced.HelpOnDemand/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using Cocona;
+using Cocona.Help;
+
+namespace CoconaSample.Advanced.HelpOnDemand
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            CoconaApp.Run<Program>(args);
+        }
+
+        public void ForContext(bool optionA, [FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
+        {
+            // Show commands help. (same as `./HelpOnDemand --help`)
+            Console.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
+        }
+
+        public void ForCommand(bool optionA, [FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
+        {
+            // Show a help for this command. (same as `./HelpOnDemand for-command --help`)
+            Console.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentCommand());
+        }
+    }
+}

--- a/src/Cocona.Core/Command/BuiltIn/BuiltInPrimaryCommand.cs
+++ b/src/Cocona.Core/Command/BuiltIn/BuiltInPrimaryCommand.cs
@@ -11,20 +11,14 @@ namespace Cocona.Command.BuiltIn
 {
     public class BuiltInPrimaryCommand
     {
-        private readonly ICoconaAppContextAccessor _appContext;
         private readonly ICoconaConsoleProvider _console;
-        private readonly ICoconaCommandHelpProvider _commandHelpProvider;
-        private readonly ICoconaHelpRenderer _helpRenderer;
-        private readonly ICoconaCommandProvider _commandProvider;
+        private readonly ICoconaHelpMessageBuilder _helpBuilder;
         private static readonly MethodInfo _methodShowDefaultMessage = typeof(BuiltInPrimaryCommand).GetMethod(nameof(ShowDefaultMessage), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
-        public BuiltInPrimaryCommand(ICoconaAppContextAccessor appContext, ICoconaConsoleProvider console, ICoconaCommandHelpProvider commandHelpProvider, ICoconaHelpRenderer helpRenderer, ICoconaCommandProvider commandProvider)
+        public BuiltInPrimaryCommand(ICoconaConsoleProvider console, ICoconaHelpMessageBuilder helpBuilder)
         {
-            _appContext = appContext;
             _console = console;
-            _commandHelpProvider = commandHelpProvider;
-            _helpRenderer = helpRenderer;
-            _commandProvider = commandProvider;
+            _helpBuilder = helpBuilder;
         }
 
         public static CommandDescriptor GetCommand(string description)
@@ -46,9 +40,7 @@ namespace Cocona.Command.BuiltIn
 
         private void ShowDefaultMessage()
         {
-            var commandStack = _appContext.Current!.Features.Get<ICoconaCommandFeature>().CommandStack!;
-            var commandCollection = commandStack.LastOrDefault()?.SubCommands ?? _commandProvider.GetCommandCollection();
-            _console.Output.Write(_helpRenderer.Render(_commandHelpProvider.CreateCommandsIndexHelp(commandCollection, commandStack)));
+            _console.Output.Write(_helpBuilder.BuildAndRenderForCurrentContext());
         }
 
         public static bool IsBuiltInCommand(CommandDescriptor command)

--- a/src/Cocona.Core/Command/CoconaCommandResolver.cs
+++ b/src/Cocona.Core/Command/CoconaCommandResolver.cs
@@ -52,7 +52,7 @@ namespace Cocona.Command
                     // NOTE: Skip a first argument that is command name.
                     args = args.Skip(1).ToArray();
 
-                    // If the command have nested sub-commands, try to restart parse command.
+                    // If the command has nested sub-commands, try to restart parse command.
                     if (matchedCommand.SubCommands != null)
                     {
                         commandCollection = matchedCommand.SubCommands;

--- a/src/Cocona.Core/Help/CoconaHelpMessageBuilder.cs
+++ b/src/Cocona.Core/Help/CoconaHelpMessageBuilder.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using Cocona.Application;
+using Cocona.Command;
+using Cocona.Command.Features;
+using Cocona.Help.DocumentModel;
+
+namespace Cocona.Help
+{
+    public class CoconaHelpMessageBuilder : ICoconaHelpMessageBuilder
+    {
+        private readonly ICoconaAppContextAccessor _appContext;
+        private readonly ICoconaCommandHelpProvider _commandHelpProvider;
+        private readonly ICoconaHelpRenderer _helpRenderer;
+        private readonly ICoconaCommandProvider _commandProvider;
+
+        public CoconaHelpMessageBuilder(ICoconaAppContextAccessor appContext, ICoconaCommandHelpProvider commandHelpProvider, ICoconaHelpRenderer helpRenderer, ICoconaCommandProvider commandProvider)
+        {
+            _appContext = appContext;
+            _commandHelpProvider = commandHelpProvider;
+            _helpRenderer = helpRenderer;
+            _commandProvider = commandProvider;
+        }
+
+        public string BuildAndRenderForCurrentContext()
+        {
+            return _helpRenderer.Render(BuildForCurrentContext());
+        }
+
+        public HelpMessage BuildForCurrentContext()
+        {
+            return BuildFromCurrentContextCore(respectCurrentCommand: false);
+        }
+
+
+        public string BuildAndRenderForCurrentCommand()
+        {
+            return _helpRenderer.Render(BuildForCurrentCommand());
+        }
+
+        public HelpMessage BuildForCurrentCommand()
+        {
+            return BuildFromCurrentContextCore(respectCurrentCommand: true);
+        }
+
+        private HelpMessage BuildFromCurrentContextCore(bool respectCurrentCommand)
+        {
+            var feature = _appContext.Current!.Features.Get<ICoconaCommandFeature>()!;
+            var commandCollection = feature.CommandCollection ?? _commandProvider.GetCommandCollection(); // nested or root
+
+            // If `respectCurrentCommand` is `true`, treats the current command as a target.
+            // When called by `--help`, the original command is put on the CommandStack.
+            // When directly call the method, the CommandStack may be empty.
+            var targetCommand = respectCurrentCommand ? feature.Command : feature.CommandStack.LastOrDefault();
+
+            var help = targetCommand is null
+                ? _commandHelpProvider.CreateCommandsIndexHelp(commandCollection, Array.Empty<CommandDescriptor>())
+                : targetCommand.IsPrimaryCommand || targetCommand.Flags.HasFlag(CommandFlags.SubCommandsEntryPoint)
+                    ? _commandHelpProvider.CreateCommandsIndexHelp(commandCollection, feature.CommandStack.Take(feature.CommandStack.Count - 1).ToArray())
+                    : _commandHelpProvider.CreateCommandHelp(targetCommand, feature.CommandStack.Take(feature.CommandStack.Count - 1).ToArray());
+
+            return help;
+        }
+    }
+}

--- a/src/Cocona.Core/Help/ICoconaHelpMessageBuilder.cs
+++ b/src/Cocona.Core/Help/ICoconaHelpMessageBuilder.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Text;
+using Cocona.Help.DocumentModel;
+
+namespace Cocona.Help
+{
+    /// <summary>
+    /// Provides a help message based on the current context.
+    /// </summary>
+    public interface ICoconaHelpMessageBuilder
+    {
+        /// <summary>
+        /// Build a help message based on the current context.
+        /// </summary>
+        /// <returns></returns>
+        HelpMessage BuildForCurrentContext();
+
+        /// <summary>
+        /// Build a help message and render as string based on the current context.
+        /// </summary>
+        /// <returns></returns>
+        string BuildAndRenderForCurrentContext();
+
+        /// <summary>
+        /// Build a help message based on the current command.
+        /// </summary>
+        /// <returns></returns>
+        HelpMessage BuildForCurrentCommand();
+
+        /// <summary>
+        /// Build a help message and render as string based on the current command.
+        /// </summary>
+        /// <returns></returns>
+        string BuildAndRenderForCurrentCommand();
+    }
+}

--- a/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
+++ b/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Extensions.Hosting
             services.TryAddTransient<ICoconaCommandResolver, CoconaCommandResolver>();
             services.TryAddTransient<ICoconaHelpRenderer, CoconaHelpRenderer>();
             services.TryAddTransient<ICoconaCommandHelpProvider, CoconaCommandHelpProvider>();
+            services.TryAddTransient<ICoconaHelpMessageBuilder, CoconaHelpMessageBuilder>();
 
             return services;
         }

--- a/test/Cocona.Test/Help/CoconaHelpMessageBuilderTest.cs
+++ b/test/Cocona.Test/Help/CoconaHelpMessageBuilderTest.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Cocona.Application;
+using Cocona.Command;
+using Cocona.Command.BuiltIn;
+using Cocona.Command.Features;
+using Cocona.Help;
+using Cocona.Help.DocumentModel;
+using Cocona.Test.Command.CommandResolver;
+using FluentAssertions;
+using Xunit;
+
+namespace Cocona.Test.Help
+{
+    public class CoconaHelpMessageBuilderTest
+    {
+        [Fact]
+        public void Single()
+        {
+            // $ ./app-single --help
+            var commandProvider = new CoconaCommandProvider(new[] {typeof(TestCommands_Single) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandStack = new[] { commandCollectionRoot.All.First() }; // --help (OptionLikeCommand) pushes the command to the stack.
+
+            var targetCommand = BuiltInOptionLikeCommands.Help.Command;
+            var commandCollection = commandCollectionRoot;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentContext();
+            help.Should().Be("IndexHelp;Commands=Foo;SubCommandStack="); // If the collection has only one command, a generated help is always IndexHelp.
+        }
+
+        [Fact]
+        public void Single_Command()
+        {
+            // $ ./app-single (build a message in the command)
+            var commandProvider = new CoconaCommandProvider(new[] { typeof(TestCommands_Single) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandStack = Array.Empty<CommandDescriptor>();
+
+            var targetCommand = commandCollectionRoot.Primary;
+            var commandCollection = commandCollectionRoot;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentCommand();
+            help.Should().Be("IndexHelp;Commands=Foo;SubCommandStack="); // If the collection has only one command, a generated help is always IndexHelp.
+        }
+
+        [Fact]
+        public void Multiple_Context_Index()
+        {
+            // $ ./app-multiple --help
+            var commandProvider = new CoconaCommandProvider(new[] { typeof(TestCommands_Multiple) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandStack = Array.Empty<CommandDescriptor>();
+
+            var targetCommand = BuiltInPrimaryCommand.GetCommand(string.Empty); // `TestCommands_Multiple` has no primary command. Use BuiltInPrimaryCommand.
+            var commandCollection = commandCollectionRoot;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentContext();
+            help.Should().Be("IndexHelp;Commands=Foo,Bar;SubCommandStack=");
+        }
+
+        [Fact]
+        public void Multiple_Context_Command()
+        {
+            // $ ./app-multiple Foo --help
+            var commandProvider = new CoconaCommandProvider(new[] { typeof(TestCommands_Multiple) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandStack = new [] { commandCollectionRoot.All.First(x => x.Name == "Foo") }; // --help (OptionLikeCommand) pushes the command to the stack.
+
+            var targetCommand = BuiltInOptionLikeCommands.Help.Command;
+            var commandCollection = commandCollectionRoot;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentContext();
+            help.Should().Be("Command;Name=Foo;SubCommandStack=");
+        }
+
+        [Fact]
+        public void Multiple_Command()
+        {
+            // $ ./app-multiple Foo (call from `Foo` method)
+            var commandProvider = new CoconaCommandProvider(new[] { typeof(TestCommands_Multiple) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandStack = Array.Empty<CommandDescriptor>();
+
+            var targetCommand = commandCollectionRoot.All.First(x => x.Name == "Foo");
+            var commandCollection = commandCollectionRoot;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentCommand();
+            help.Should().Be("Command;Name=Foo;SubCommandStack=");
+        }
+
+
+        [Fact]
+        public void Nested_Index()
+        {
+            // $ ./app-nested 
+            var commandProvider = new CoconaCommandProvider(new[] { typeof(TestCommands_Nested) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandStack = Array.Empty<CommandDescriptor>();
+
+            var targetCommand = BuiltInPrimaryCommand.GetCommand(string.Empty); // `TestCommands_Multiple` has no primary command. Use BuiltInPrimaryCommand.
+            var commandCollection = commandCollectionRoot;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentContext();
+            help.Should().Be("IndexHelp;Commands=Foo,Bar,TestCommands_Nested_1;SubCommandStack=");
+        }
+
+        [Fact]
+        public void Nested_Context_Command()
+        {
+            // $ ./app-nested Foo --help
+            var commandProvider = new CoconaCommandProvider(new[] { typeof(TestCommands_Nested) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandStack = new[] { commandCollectionRoot.All.First(x => x.Name == "Foo") }; // --help (OptionLikeCommand) pushes the command to the stack.
+
+            var targetCommand = BuiltInOptionLikeCommands.Help.Command;
+            var commandCollection = commandCollectionRoot;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentContext();
+            help.Should().Be("Command;Name=Foo;SubCommandStack=");
+        }
+
+        [Fact]
+        public void Nested_Context_Command_Nested()
+        {
+            // $ ./app-nested TestCommands_Nested_1 Baz --help
+            var commandProvider = new CoconaCommandProvider(new[] { typeof(TestCommands_Nested) });
+            var commandCollectionRoot = commandProvider.GetCommandCollection();
+            var commandNested = commandCollectionRoot.All.First(x => x.Name == "TestCommands_Nested_1");
+            var commandBaz = commandNested.SubCommands.All.First(x => x.Name == "Baz");
+            var commandStack = new[] { commandNested, commandBaz }; // --help (OptionLikeCommand) pushes the command to the stack.
+
+            var targetCommand = BuiltInOptionLikeCommands.Help.Command;
+            var commandCollection = commandNested.SubCommands;
+
+            var appContext = new CoconaAppContext(targetCommand, default);
+            appContext.Features.Set<ICoconaCommandFeature>(new CoconaCommandFeature(commandCollection, targetCommand, commandStack, new object() /* unused */));
+            var helpBuilder = new CoconaHelpMessageBuilder(
+                new FakeAppContextAccessor(appContext),
+                new FakeCommandHelpProvider(),
+                new FakeHelpRenderer(),
+                commandProvider
+            );
+
+            var help = helpBuilder.BuildAndRenderForCurrentContext();
+            help.Should().Be("Command;Name=Baz;SubCommandStack=TestCommands_Nested_1");
+        }
+
+
+        private class TestCommands_Single
+        {
+            public void Foo(bool option0, [Argument]string args) { }
+        }
+
+        private class TestCommands_Multiple
+        {
+            public void Foo(bool option0, [Argument] string args) { }
+            public void Bar(bool option0, [Argument] string args) { }
+        }
+
+        [HasSubCommands(typeof(TestCommands_Nested_1))]
+        private class TestCommands_Nested
+        {
+            public void Foo(bool option0, [Argument] string args) { }
+            public void Bar(bool option0, [Argument] string args) { }
+        }
+        private class TestCommands_Nested_1
+        {
+            public void Baz(bool option0, [Argument] string args) { }
+            public void Hauhau(bool option0, [Argument] string args) { }
+        }
+
+        private class FakeAppContextAccessor : ICoconaAppContextAccessor
+        {
+            public CoconaAppContext? Current { get; set; }
+
+            public FakeAppContextAccessor(CoconaAppContext? context)
+            {
+                Current = context;
+            }
+        }
+
+        private class FakeCommandHelpProvider : ICoconaCommandHelpProvider
+        {
+            public HelpMessage CreateCommandHelp(CommandDescriptor command, IReadOnlyList<CommandDescriptor> subCommandStack)
+                => new HelpMessage(new HelpSection(
+                    new HelpParagraph("Command"),
+                    new HelpParagraph("Name=" + command.Name),
+                    new HelpParagraph("SubCommandStack=" + string.Join(",", subCommandStack.Select(x => x.Name)))
+                ));
+
+            public HelpMessage CreateCommandsIndexHelp(CommandCollection commandCollection, IReadOnlyList<CommandDescriptor> subCommandStack)
+                => new HelpMessage(new HelpSection(
+                    new HelpParagraph("IndexHelp"),
+                    new HelpParagraph("Commands=" + string.Join(",", commandCollection.All.Select(x => x.Name))),
+                    new HelpParagraph("SubCommandStack=" + string.Join(",", subCommandStack.Select(x => x.Name)))
+                ));
+
+            public HelpMessage CreateVersionHelp()
+                => new HelpMessage(new HelpSection(
+                    new HelpParagraph("Version")
+                ));
+        }
+
+        private class FakeHelpRenderer : ICoconaHelpRenderer
+        {
+            public string Render(HelpMessage message)
+            {
+                return string.Join(";", message.Children[0].Children.OfType<HelpParagraph>().Select(x => x.Content));
+            }
+        }
+    }
+}

--- a/test/Cocona.Test/Integration/EndToEndTest.cs
+++ b/test/Cocona.Test/Integration/EndToEndTest.cs
@@ -184,6 +184,16 @@ namespace Cocona.Test.Integration
         }
 
         [Fact]
+        public void CoconaApp_Run_Multiple_Help_Command()
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple>(new string[] { "konnichiwa", "--help" });
+
+            stdOut.Should().Contain("Usage:");
+            stdOut.Should().Contain(" konnichiwa [--help]");
+            exitCode.Should().Be(129);
+        }
+
+        [Fact]
         public void CoconaApp_Run_Multiple_Version()
         {
             var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple>(new string[] { "--version" });


### PR DESCRIPTION
Introduce HelpMessageBuilder that help messages can be displayed from user code. (ref #22)

```csharp
// Show commands help. (same as `./HelpOnDemand --help`)
public void ForContext(bool optionA, [FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
{
    Console.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
}

// Show help for this command. (same as `./HelpOnDemand for-command --help`)
public void ForCommand(bool optionA, [FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
{
    Console.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentCommand());
}
```