### PR TITLE
Introduce Parameter Set

### DIFF
--- a/Cocona.sln
+++ b/Cocona.sln
@@ -73,17 +73,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoconaSample.Advanced.Optio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoconaSample.Advanced.CommandMethodForwarding", "samples\Advanced.CommandMethodForwarding\CoconaSample.Advanced.CommandMethodForwarding.csproj", "{2E5BEBF1-FCDE-4DA3-9A06-4EC721E89AFD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.Advanced.HelpOnDemand", "samples\Advanced.HelpOnDemand\CoconaSample.Advanced.HelpOnDemand.csproj", "{089D815D-2199-4CCA-9BAF-F7386F883063}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoconaSample.Advanced.HelpOnDemand", "samples\Advanced.HelpOnDemand\CoconaSample.Advanced.HelpOnDemand.csproj", "{089D815D-2199-4CCA-9BAF-F7386F883063}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub Actions", "GitHub Actions", "{F7ED9A50-845E-4A47-9F4E-A0C372082D76}"
-ProjectSection(SolutionItems) = preProject
-	.github\workflows\build.yaml = .github\workflows\build.yaml
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yaml = .github\workflows\build.yaml
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Azure Pipelines", "Azure Pipelines", "{C5099F3C-62C3-45F3-BFB9-194E0CEF55DB}"
-ProjectSection(SolutionItems) = preProject
-	.azure-pipelines\build.yml = .azure-pipelines\build.yml
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		.azure-pipelines\build.yml = .azure-pipelines\build.yml
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.InAction.ParameterSet", "samples\InAction.ParameterSet\CoconaSample.InAction.ParameterSet.csproj", "{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -203,6 +205,10 @@ Global
 		{089D815D-2199-4CCA-9BAF-F7386F883063}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{089D815D-2199-4CCA-9BAF-F7386F883063}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{089D815D-2199-4CCA-9BAF-F7386F883063}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -235,6 +241,7 @@ Global
 		{089D815D-2199-4CCA-9BAF-F7386F883063} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{F7ED9A50-845E-4A47-9F4E-A0C372082D76} = {09F6C99E-D874-4C82-90AA-A37E5BE707C4}
 		{C5099F3C-62C3-45F3-BFB9-194E0CEF55DB} = {09F6C99E-D874-4C82-90AA-A37E5BE707C4}
+		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DBA26EF-235B-4656-A5DD-00C266A42735}

--- a/perf/Cocona.Benchmark.Performance/CommandProviderBenchmark.cs
+++ b/perf/Cocona.Benchmark.Performance/CommandProviderBenchmark.cs
@@ -63,7 +63,8 @@ namespace Cocona.Benchmark.Performance
                 new[] { typeof(TestCommand_Current) },
                 treatPublicMethodsAsCommands: true,
                 enableConvertCommandNameToLowerCase: true,
-                enableConvertOptionNameToLowerCase: true
+                enableConvertOptionNameToLowerCase: true,
+                enableConvertArgumentNameToLowerCase: true
             ), enableShellCompletionSupport:true);
 
             var commands = provider.GetCommandCollection();

--- a/samples/InAction.ParameterSet/CoconaSample.InAction.ParameterSet.csproj
+++ b/samples/InAction.ParameterSet/CoconaSample.InAction.ParameterSet.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cocona\Cocona.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/InAction.ParameterSet/Program.cs
+++ b/samples/InAction.ParameterSet/Program.cs
@@ -1,0 +1,39 @@
+using System;
+using Cocona;
+
+namespace CoconaSample.InAction.ParameterSet
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            CoconaApp.Run<Program>(args);
+        }
+
+        /// <summary>
+        /// Define a set of Options and Arguments that are common to multiple commands.
+        /// </summary>
+        public record CommonParameters(
+            [Option('t', Description = "Specifies the remote host to connect.")]
+            string Host,
+            [Option('p', Description = "Port to connect to on the remote host.")]
+            int Port,
+            [Option('u', Description = "Specifies the user to log in as on the remote host.")]
+            string User = "root",
+            [Option('f', Description = "Perform without user confirmation.")]
+            bool Force = false
+        ) : ICommandParameterSet;
+
+        public void Add(CommonParameters commonParams, [Argument] string from, [Argument] string to)
+        {
+            Console.WriteLine($"Add: {commonParams.User}@{commonParams.Host}:{commonParams.Port} {(commonParams.Force ? " (Force)" : "")}");
+            Console.WriteLine($"{from} -> {to}");
+        }
+
+        public void Update(CommonParameters commonParams, [Option('r', Description = "Traverse recursively to perform.")] bool recursive, [Argument] string path)
+        {
+            Console.WriteLine($"Update: {commonParams.User}@{commonParams.Host}:{commonParams.Port} {(commonParams.Force ? " (Force)" : "")}");
+            Console.WriteLine($"{path}{(recursive ? " (Recursive)" : "")}");
+        }
+    }
+}

--- a/src/Cocona.Core/ArgumentAttribute.cs
+++ b/src/Cocona.Core/ArgumentAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +7,7 @@ namespace Cocona
     /// <summary>
     /// Specifies the parameter that should be treated as command argument.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public class ArgumentAttribute : Attribute
     {
         /// <summary>

--- a/src/Cocona.Core/Command/CoconaCommandProvider.cs
+++ b/src/Cocona.Core/Command/CoconaCommandProvider.cs
@@ -540,7 +540,7 @@ namespace Cocona.Command
                     _name = name;
                 }
 
-                public void AddArgument(CommandParameterAttributeSet attrSet, Type type, string name, CoconaDefaultValue defaultValue, Action<object, object> setter)
+                public void AddArgument(CommandParameterAttributeSet attrSet, Type type, string name, CoconaDefaultValue defaultValue, Action<object, object?> setter)
                 {
                     var argumentDescriptor = _parent.CreateArgument(attrSet, type, name, defaultValue);
                     _parent._defaultArgOrder++;
@@ -549,7 +549,7 @@ namespace Cocona.Command
                     _memberDescriptors.Add(new CommandParameterSetMemberDescriptor(argumentDescriptor, setter));
                 }
 
-                public void AddOption(CommandParameterAttributeSet attrSet, Type type, string name, CoconaDefaultValue defaultValue, Action<object, object> setter)
+                public void AddOption(CommandParameterAttributeSet attrSet, Type type, string name, CoconaDefaultValue defaultValue, Action<object, object?> setter)
                 {
                     var optionDescriptor = _parent.CreateOption(attrSet, type, name, defaultValue);
 
@@ -564,7 +564,7 @@ namespace Cocona.Command
                     _memberDescriptors.Add(new CommandParameterSetMemberDescriptor(optionDescriptor, setter));
                 }
 
-                public void AddFromService(Type type, string name, Action<object, object> setter)
+                public void AddFromService(Type type, string name, Action<object, object?> setter)
                 {
                     _memberDescriptors.Add(new CommandParameterSetMemberDescriptor(_parent.CreateFromService(type, name), setter));
                 }

--- a/src/Cocona.Core/Command/CommandArgumentDescriptor.cs
+++ b/src/Cocona.Core/Command/CommandArgumentDescriptor.cs
@@ -1,4 +1,4 @@
-﻿using Cocona.Internal;
+using Cocona.Internal;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Cocona.Core/Command/CommandParameterSetDescriptor.cs
+++ b/src/Cocona.Core/Command/CommandParameterSetDescriptor.cs
@@ -24,9 +24,9 @@ namespace Cocona.Command
     public class CommandParameterSetMemberDescriptor
     {
         public ICommandParameterDescriptor ParameterDescriptor { get; }
-        public Action<object, object> Setter { get; }
+        public Action<object, object?> Setter { get; }
 
-        public CommandParameterSetMemberDescriptor(ICommandParameterDescriptor parameterDescriptor, Action<object, object> setter)
+        public CommandParameterSetMemberDescriptor(ICommandParameterDescriptor parameterDescriptor, Action<object, object?> setter)
         {
             ParameterDescriptor = parameterDescriptor;
             Setter = setter;

--- a/src/Cocona.Core/Command/CommandParameterSetDescriptor.cs
+++ b/src/Cocona.Core/Command/CommandParameterSetDescriptor.cs
@@ -10,17 +10,33 @@ namespace Cocona.Command
         public Type ParameterSetType { get; }
         public string Name { get; }
         public IReadOnlyList<Attribute> ParameterAttributes { get; }
-        public IReadOnlyList<CommandParameterSetMemberDescriptor> MemberDescriptors { get; }
+        public IReadOnlyList<CommandParameterSetMemberDescriptor> Members { get; }
 
-        public CommandParameterSetDescriptor(Type parameterSetType, string name, IReadOnlyList<Attribute> parameterAttributes, IReadOnlyList<CommandParameterSetMemberDescriptor> memberDescriptors)
+        public CommandParameterSetDescriptor(Type parameterSetType, string name, IReadOnlyList<Attribute> parameterAttributes, IReadOnlyList<CommandParameterSetMemberDescriptor> members)
         {
             ParameterSetType = parameterSetType ?? throw new ArgumentNullException(nameof(parameterSetType));
             Name = name ?? throw new ArgumentNullException(nameof(name));
             ParameterAttributes = parameterAttributes ?? throw new ArgumentNullException(nameof(parameterAttributes));
-            MemberDescriptors = memberDescriptors ?? throw new ArgumentNullException(nameof(memberDescriptors));
+            Members = members ?? throw new ArgumentNullException(nameof(members));
         }
     }
 
+    [DebuggerDisplay("ParameterSet (Parameterized): {Name,nq} (ParameterSetType={ParameterSetType.FullName,nq}")]
+    public class CommandParameterizedParameterSetDescriptor : ICommandParameterDescriptor
+    {
+        public Type ParameterSetType { get; }
+        public string Name { get; }
+        public IReadOnlyList<Attribute> ParameterAttributes { get; }
+        public IReadOnlyList<ICommandParameterDescriptor> Parameters { get; }
+
+        public CommandParameterizedParameterSetDescriptor(Type parameterSetType, string name, IReadOnlyList<Attribute> parameterAttributes, IReadOnlyList<ICommandParameterDescriptor> parameters)
+        {
+            ParameterSetType = parameterSetType ?? throw new ArgumentNullException(nameof(parameterSetType));
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            ParameterAttributes = parameterAttributes ?? throw new ArgumentNullException(nameof(parameterAttributes));
+            Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        }
+    }
     public class CommandParameterSetMemberDescriptor
     {
         public ICommandParameterDescriptor ParameterDescriptor { get; }

--- a/src/Cocona.Core/Command/CommandParameterSetDescriptor.cs
+++ b/src/Cocona.Core/Command/CommandParameterSetDescriptor.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Cocona.Command
+{
+    [DebuggerDisplay("ParameterSet: {Name,nq} (ParameterSetType={ParameterSetType.FullName,nq}")]
+    public class CommandParameterSetDescriptor : ICommandParameterDescriptor
+    {
+        public Type ParameterSetType { get; }
+        public string Name { get; }
+        public IReadOnlyList<Attribute> ParameterAttributes { get; }
+        public IReadOnlyList<CommandParameterSetMemberDescriptor> MemberDescriptors { get; }
+
+        public CommandParameterSetDescriptor(Type parameterSetType, string name, IReadOnlyList<Attribute> parameterAttributes, IReadOnlyList<CommandParameterSetMemberDescriptor> memberDescriptors)
+        {
+            ParameterSetType = parameterSetType ?? throw new ArgumentNullException(nameof(parameterSetType));
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            ParameterAttributes = parameterAttributes ?? throw new ArgumentNullException(nameof(parameterAttributes));
+            MemberDescriptors = memberDescriptors ?? throw new ArgumentNullException(nameof(memberDescriptors));
+        }
+    }
+
+    public class CommandParameterSetMemberDescriptor
+    {
+        public ICommandParameterDescriptor ParameterDescriptor { get; }
+        public Action<object, object> Setter { get; }
+
+        public CommandParameterSetMemberDescriptor(ICommandParameterDescriptor parameterDescriptor, Action<object, object> setter)
+        {
+            ParameterDescriptor = parameterDescriptor;
+            Setter = setter;
+        }
+    }
+}

--- a/src/Cocona.Core/HasDefaultValueAttribute.cs
+++ b/src/Cocona.Core/HasDefaultValueAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cocona
+{
+    /// <summary>
+    /// An attribute indicating that the property or field is optional, for use in classes that implement <see cref="ICommandParameterSet"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
+    public class HasDefaultValueAttribute : Attribute
+    {
+    }
+}

--- a/src/Cocona.Core/ICommandParameterSet.cs
+++ b/src/Cocona.Core/ICommandParameterSet.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Cocona
+{
+    public interface ICommandParameterSet
+    {
+    }
+}

--- a/src/Cocona.Core/ICommandParameterSet.cs
+++ b/src/Cocona.Core/ICommandParameterSet.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace Cocona
 {
+    /// <summary>
+    /// Marker interface for a set of command parameters.
+    /// </summary>
     public interface ICommandParameterSet
     {
     }

--- a/src/Cocona.Core/OptionAttribute.cs
+++ b/src/Cocona.Core/OptionAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +7,7 @@ namespace Cocona
     /// <summary>
     /// Specifies the parameter that should be treated as command option.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public class OptionAttribute : Attribute
     {
         /// <summary>

--- a/src/Cocona.Lite/CoconaLiteAppOptions.cs
+++ b/src/Cocona.Lite/CoconaLiteAppOptions.cs
@@ -24,6 +24,11 @@ namespace Cocona
         public bool EnableConvertOptionNameToLowerCase { get; set; } = true;
 
         /// <summary>
+        /// Specify enable to convert argument name to lower-case or not (e.g. ArgumentName -> argument-name)
+        /// </summary>
+        public bool EnableConvertArgumentNameToLowerCase { get; set; } = true;
+
+        /// <summary>
         /// Specify enable shell completion support. The default value is true.
         /// </summary>
         public bool EnableShellCompletionSupport { get; set; } = true;

--- a/src/Cocona/Hosting/CoconaAppOptions.cs
+++ b/src/Cocona/Hosting/CoconaAppOptions.cs
@@ -25,6 +25,11 @@ namespace Cocona.Hosting
         public bool EnableConvertOptionNameToLowerCase { get; set; } = true;
 
         /// <summary>
+        /// Specify enable to convert argument name to lower-case or not (e.g. ArgumentName -> argument-name)
+        /// </summary>
+        public bool EnableConvertArgumentNameToLowerCase { get; set; } = true;
+
+        /// <summary>
         /// Specify enable shell completion support. The default value is true.
         /// </summary>
         public bool EnableShellCompletionSupport { get; set; } = true;

--- a/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
+++ b/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
@@ -53,9 +53,10 @@ namespace Microsoft.Extensions.Hosting
                         options.CommandTypes.ToArray(),
                         options.TreatPublicMethodsAsCommands,
                         options.EnableConvertOptionNameToLowerCase,
-                        options.EnableConvertCommandNameToLowerCase
+                        options.EnableConvertCommandNameToLowerCase,
+                        options.EnableConvertArgumentNameToLowerCase
                     ),
-                    options.EnableShellCompletionSupport
+                        options.EnableShellCompletionSupport
                 );
             });
             services.TryAddSingleton<ICoconaCommandLineArgumentProvider>(serviceProvider =>

--- a/test/Cocona.Test/Command/CommandProvider/CommandParameterSetTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CommandParameterSetTest.cs
@@ -93,15 +93,18 @@ namespace Cocona.Test.Command.CommandProvider
             paramDesc0.Name.Should().Be("BooleanOption");
             paramDesc0.DefaultValue.HasValue.Should().BeTrue();
             paramDesc0.DefaultValue.Value.Should().Be(false);
+            paramDesc0.IsRequired.Should().BeFalse();
 
             var paramDesc1 = (CommandOptionDescriptor)paramSetDesc.MemberDescriptors[1].ParameterDescriptor;
             paramDesc1.Name.Should().Be("StringOption");
             paramDesc1.DefaultValue.HasValue.Should().BeTrue();
             paramDesc1.DefaultValue.Value.Should().Be("DefaultValue");
+            paramDesc1.IsRequired.Should().BeFalse();
 
             var paramDesc2 = (CommandOptionDescriptor)paramSetDesc.MemberDescriptors[2].ParameterDescriptor;
             paramDesc2.Name.Should().Be("StringOption_WithoutHasDefaultValue");
             paramDesc2.DefaultValue.HasValue.Should().BeFalse();
+            paramDesc2.IsRequired.Should().BeTrue();
         }
 
         [Fact]

--- a/test/Cocona.Test/Command/CommandProvider/CommandParameterSetTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CommandParameterSetTest.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Cocona.Command;
+using FluentAssertions;
+using Xunit;
+
+#pragma warning disable 169
+#pragma warning disable 649
+
+namespace Cocona.Test.Command.CommandProvider
+{
+    public class CommandParameterSetTest
+    {
+        [Fact]
+        public void ParameterSet()
+        {
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+
+            command.Parameters.Should().HaveCount(1);
+            command.Options.Should().NotBeEmpty();
+            command.Arguments.Should().NotBeEmpty();
+            command.Options[0].Name.Should().Be("BooleanFlag");
+            command.Options[1].Name.Should().Be("BooleanFlagImplicit");
+            command.Arguments[0].Name.Should().Be("Argument");
+        }
+
+        [Fact]
+        public void ParameterSetMustNotBeOption()
+        {
+            Assert.Throws<CoconaException>(() =>
+            {
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Option)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            });
+        }
+        [Fact]
+        public void ParameterSetMustNotBeArgument()
+        {
+            Assert.Throws<CoconaException>(() =>
+            {
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Argument)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            });
+        }
+
+        [Fact]
+        public void Duplicated_Option_Option()
+        {
+            Assert.Throws<CoconaException>(() =>
+            {
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.OptionWithParameterSet_Duplicated)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            });
+        }
+
+        [Fact]
+        public void Duplicated_Option_Argument()
+        {
+            // Arguments can be declared multiple times.
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ArgumentWithParameterSet_Duplicated)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+        }
+
+        //[Fact]
+        //public void Record()
+        //{
+        //    var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Record)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+
+        //    command.Parameters.Should().HaveCount(1);
+        //    command.Options.Should().NotBeEmpty();
+        //    command.Arguments.Should().NotBeEmpty();
+        //    command.Options[0].Name.Should().Be("BooleanFlag");
+        //    command.Arguments[0].Name.Should().Be("Argument");
+        //}
+
+        [Fact]
+        public void ClassIsNotMarkedAsParameterSet()
+        {
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_NotICommandParameterSet)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            command.Parameters[0].Should().NotBeOfType<CommandParameterSetDescriptor>();
+        }
+
+        [Fact]
+        public void DefaultValue()
+        {
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_DefaultValue)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            command.Parameters[0].Should().BeOfType<CommandParameterSetDescriptor>();
+
+            var paramSetDesc = ((CommandParameterSetDescriptor)command.Parameters[0]);
+            
+            // The boolean property is treated as optional flag implicitly.
+            var paramDesc0 = (CommandOptionDescriptor)paramSetDesc.MemberDescriptors[0].ParameterDescriptor;
+            paramDesc0.Name.Should().Be("BooleanOption");
+            paramDesc0.DefaultValue.HasValue.Should().BeTrue();
+            paramDesc0.DefaultValue.Value.Should().Be(false);
+
+            var paramDesc1 = (CommandOptionDescriptor)paramSetDesc.MemberDescriptors[1].ParameterDescriptor;
+            paramDesc1.Name.Should().Be("StringOption");
+            paramDesc1.DefaultValue.HasValue.Should().BeTrue();
+            paramDesc1.DefaultValue.Value.Should().Be("DefaultValue");
+
+            var paramDesc2 = (CommandOptionDescriptor)paramSetDesc.MemberDescriptors[2].ParameterDescriptor;
+            paramDesc2.Name.Should().Be("StringOption_WithoutHasDefaultValue");
+            paramDesc2.DefaultValue.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasNoParameterlessConstructor()
+        {
+            Assert.Throws<CoconaException>(() =>
+            {
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_NoParameterlessConstructor)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            });
+        }
+
+        class CommandTest
+        {
+            public void ParameterSet(TestParameterSet paramSet) { }
+            public void ParameterSet_Option([Option] TestParameterSet paramSet) { }
+            public void ParameterSet_Argument([Argument] TestParameterSet paramSet) { }
+            public void OptionWithParameterSet(string option0, TestParameterSet paramSet) { }
+            public void OptionWithParameterSet_Option(string option0, [Option] TestParameterSet paramSet) { }
+            public void OptionWithParameterSet_Argument(string option0, [Argument] TestParameterSet paramSet) { }
+
+            public void OptionWithParameterSet_Duplicated([Option] bool BooleanFlag, TestParameterSet paramSet) { }
+            public void ArgumentWithParameterSet_Duplicated([Argument] string Argument, TestParameterSet paramSet) { }
+
+            public void ParameterSet_Record(TestParameterSet_Record paramSet) { }
+            public void ParameterSet_DefaultValue(TestParameterSet_DefaultValue paramSet) { }
+            public void ParameterSet_NotICommandParameterSet(TestParameterSet_NotICommandParameterSet paramSet) { }
+            public void ParameterSet_NoParameterlessConstructor(TestParameterSet_NoParameterlessConstructor paramSet) { }
+        }
+
+        class TestParameterSet_NotICommandParameterSet
+        { }
+
+        class TestParameterSet : ICommandParameterSet
+        {
+            [Option]
+            public bool BooleanFlag { get; set; }
+            public bool BooleanFlagImplicit { get; set; }
+            [Argument]
+            public string Argument { get; set; }
+        }
+
+        class TestParameterSet_Option_Prop_GetterOnly : ICommandParameterSet
+        {
+            [Option]
+            public bool BooleanFlag { get; }
+        }
+        class TestParameterSet_Option_Prop_InitSetter : ICommandParameterSet
+        {
+            [Option]
+            public bool BooleanFlag { get; init; }
+        }
+        class TestParameterSet_Option_Prop_PrivateSetter : ICommandParameterSet
+        {
+            [Option]
+            public bool BooleanFlag { get; private set; }
+        }
+        class TestParameterSet_Option_Field : ICommandParameterSet
+        {
+            [Option] public bool BooleanFlag;
+        }
+        class TestParameterSet_Option_Field_Private : ICommandParameterSet
+        {
+            [Option] private bool BooleanFlag;
+        }
+
+        record TestParameterSet_Record([property: Option]bool BooleanFlag, [property: Argument] string Argument) : ICommandParameterSet;
+
+        class TestParameterSet_DefaultValue : ICommandParameterSet
+        {
+            public bool BooleanOption { get; set; }
+            [Option, HasDefaultValue]
+            public string StringOption { get; set; } = "DefaultValue";
+            [Option]
+            public string StringOption_WithoutHasDefaultValue { get; set; } = "DefaultValue";
+        }
+        class TestParameterSet_NoParameterlessConstructor : ICommandParameterSet
+        {
+            [Option]
+            public bool BooleanFlag { get; set; }
+
+            public TestParameterSet_NoParameterlessConstructor(bool booleanFlag)
+            {
+                BooleanFlag = booleanFlag;
+            }
+        }
+
+        private static MethodInfo GetMethod<T>(string methodName)
+        {
+            return typeof(T).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public)!;
+        }
+
+    }
+}

--- a/test/Cocona.Test/Command/CommandProvider/ToCommandCaseTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/ToCommandCaseTest.cs
@@ -16,6 +16,7 @@ namespace Cocona.Test.Command.BuiltIn
             var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertCommandNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dryRun");
+            cmd.Arguments[0].Name.Should().Be("ArgName0");
         }
         [Fact]
         public void EnableCommandNameConversion()
@@ -23,6 +24,7 @@ namespace Cocona.Test.Command.BuiltIn
             var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertCommandNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
             cmd.Name.Should().Be("command-name");
             cmd.Options[0].Name.Should().Be("dryRun");
+            cmd.Arguments[0].Name.Should().Be("ArgName0");
         }
         [Fact]
         public void DisableOptionNameConversion()
@@ -30,6 +32,7 @@ namespace Cocona.Test.Command.BuiltIn
             var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertOptionNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dryRun");
+            cmd.Arguments[0].Name.Should().Be("ArgName0");
         }
         [Fact]
         public void EnableOptionNameConversion()
@@ -37,11 +40,29 @@ namespace Cocona.Test.Command.BuiltIn
             var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertOptionNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dry-run");
+            cmd.Arguments[0].Name.Should().Be("ArgName0");
+        }
+        [Fact]
+        public void DisableArgumentNameConversion()
+        {
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertArgumentNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            cmd.Name.Should().Be("CommandName");
+            cmd.Options[0].Name.Should().Be("dryRun");
+            cmd.Arguments[0].Name.Should().Be("ArgName0");
+        }
+        [Fact]
+        public void EnableArgumentNameConversion()
+        {
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertArgumentNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            cmd.Name.Should().Be("CommandName");
+            cmd.Options[0].Name.Should().Be("dryRun");
+            cmd.Arguments[0].Name.Should().Be("arg-name0");
         }
 
         class CommandTest
         {
-            public void CommandName(bool dryRun)
+            // ReSharper disable once InconsistentNaming
+            public void CommandName(bool dryRun, [Argument]string ArgName0)
             {
             }
         }

--- a/test/Cocona.Test/Command/ParameterBinder/BindParameterTest.cs
+++ b/test/Cocona.Test/Command/ParameterBinder/BindParameterTest.cs
@@ -32,14 +32,24 @@ namespace Cocona.Test.Command.ParameterBinder
 
         private CommandDescriptor CreateCommand(ICommandParameterDescriptor[] parameterDescriptors)
         {
+            var paramDescriptorsWithParameterSets = parameterDescriptors.SelectMany(x => x switch
+                {
+                    CommandOptionDescriptor _ => new ICommandParameterDescriptor[] {x},
+                    CommandArgumentDescriptor _ => new ICommandParameterDescriptor[] {x},
+                    CommandParameterSetDescriptor paramSetDesc => paramSetDesc.MemberDescriptors
+                        .Select(y => y.ParameterDescriptor).ToArray(),
+                    _ => throw new NotSupportedException(),
+                })
+                .ToArray();
+
             return new CommandDescriptor(
-                typeof(BindParameterTest).GetMethod(nameof(BindParameterTest.__Dummy)),
+                typeof(BindParameterTest).GetMethod(nameof(BindParameterTest.__Dummy))!,
                 "Test",
                 Array.Empty<string>(),
                 "",
                 parameterDescriptors,
-                parameterDescriptors.OfType<CommandOptionDescriptor>().ToArray(),
-                parameterDescriptors.OfType<CommandArgumentDescriptor>().ToArray(),
+                paramDescriptorsWithParameterSets.OfType<CommandOptionDescriptor>().ToArray(),
+                paramDescriptorsWithParameterSets.OfType<CommandArgumentDescriptor>().ToArray(),
                 Array.Empty<CommandOverloadDescriptor>(),
                 Array.Empty<CommandOptionLikeCommandDescriptor>(),
                 CommandFlags.None,
@@ -719,6 +729,93 @@ namespace Cocona.Test.Command.ParameterBinder
             invokeArgs.Should().HaveCount(2);
             invokeArgs[0].Should().BeOfType<MyService>();
             invokeArgs[1].Should().Be("argValue0");
+        }
+
+        [Fact]
+        public void BindParameterSet()
+        {
+            var commandDescriptor = CreateCommand(new ICommandParameterDescriptor[]
+                {
+                    new CommandParameterSetDescriptor(typeof(TestCommandParameterSet), "paramSet", Array.Empty<Attribute>(), new CommandParameterSetMemberDescriptor[]
+                    {
+                        new CommandParameterSetMemberDescriptor(
+                            new CommandOptionDescriptor(typeof(int), "option0", Array.Empty<char>(), "", CoconaDefaultValue.None, null, CommandOptionFlags.None, Array.Empty<Attribute>()),
+                            (x, v) => ((TestCommandParameterSet)x).Option0 = (int)v
+                        ),
+                        new CommandParameterSetMemberDescriptor(
+                            new CommandOptionDescriptor(typeof(bool), "option1", Array.Empty<char>(), "", new CoconaDefaultValue(false), null, CommandOptionFlags.None, Array.Empty<Attribute>()),
+                            (x, v) => ((TestCommandParameterSet)x).Option1 = (bool)v
+                        ),
+                        new CommandParameterSetMemberDescriptor(
+                            new CommandArgumentDescriptor(typeof(string), "arg0", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                            (x, v) => ((TestCommandParameterSet)x).Arg0 = (string)v
+                        )
+                    }),
+                }
+            );
+
+            var commandOptions = new CommandOption[] { new CommandOption(commandDescriptor.Options[0], "123", 0), };
+            var commandArguments = new CommandArgument[] { new CommandArgument("argValue0", 0), new CommandArgument("argValue1", 1), new CommandArgument("argValue2", 2), };
+
+            var invokeArgs = CreateCoconaParameterBinder().Bind(commandDescriptor, commandOptions, commandArguments);
+            invokeArgs.Should().NotBeNull();
+            var paramSet = invokeArgs[0].Should().BeOfType<TestCommandParameterSet>().Subject;
+            paramSet.Option0.Should().Be(123);
+            paramSet.Option1.Should().BeFalse();
+            paramSet.Arg0.Should().Be("argValue0");
+        }
+
+        [Fact]
+        public void BindParameterSet_Mixed()
+        {
+            var commandDescriptor = CreateCommand(new ICommandParameterDescriptor[]
+                {
+                    new CommandArgumentDescriptor(typeof(string), "arg0", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                    new CommandParameterSetDescriptor(typeof(TestCommandParameterSet), "paramSet", Array.Empty<Attribute>(), new CommandParameterSetMemberDescriptor[]
+                    {
+                        new CommandParameterSetMemberDescriptor(
+                            new CommandOptionDescriptor(typeof(int), "option0", Array.Empty<char>(), "", CoconaDefaultValue.None, null, CommandOptionFlags.None, Array.Empty<Attribute>()),
+                            (x, v) => ((TestCommandParameterSet)x).Option0 = (int)v
+                        ),
+                        new CommandParameterSetMemberDescriptor(
+                            new CommandOptionDescriptor(typeof(bool), "option1", Array.Empty<char>(), "", new CoconaDefaultValue(false), null, CommandOptionFlags.None, Array.Empty<Attribute>()),
+                            (x, v) => ((TestCommandParameterSet)x).Option1 = (bool)v
+                        ),
+                        new CommandParameterSetMemberDescriptor(
+                            new CommandArgumentDescriptor(typeof(string), "arg1", 1, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                        (x, v) => ((TestCommandParameterSet)x).Arg0 = (string)v
+                        )
+                    }),
+                    new CommandArgumentDescriptor(typeof(string), "arg2", 2, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                }
+            );
+
+            var commandOptions = new CommandOption[] { new CommandOption(commandDescriptor.Options[0], "123", 0), new CommandOption(commandDescriptor.Options[1], "true", 1), };
+            var commandArguments = new CommandArgument[] { new CommandArgument("argValue0", 0), new CommandArgument("argValue1", 1), new CommandArgument("argValue2", 2), };
+
+            var invokeArgs = CreateCoconaParameterBinder().Bind(commandDescriptor, commandOptions, commandArguments);
+            invokeArgs.Should().NotBeNull();
+            invokeArgs.Should().HaveCount(3);
+
+            invokeArgs[0].Should().Be("argValue0");
+
+            var paramSet = invokeArgs[1].Should().BeOfType<TestCommandParameterSet>().Subject;
+            paramSet.Option0.Should().Be(123);
+            paramSet.Option1.Should().BeTrue();
+            paramSet.Arg0.Should().Be("argValue1");
+
+            invokeArgs[2].Should().Be("argValue2");
+        }
+
+        class TestCommandParameterSet : ICommandParameterSet
+        {
+            [Option]
+            public int Option0 { get; set; }
+            [Option]
+            public bool Option1 { get; set; }
+
+            [Argument]
+            public string Arg0 { get; set; }
         }
     }
 }

--- a/test/Cocona.Test/Integration/EndToEndTest.cs
+++ b/test/Cocona.Test/Integration/EndToEndTest.cs
@@ -512,5 +512,29 @@ namespace Cocona.Test.Integration
                 throw new Exception("Exception!");
             }
         }
+
+        [Fact]
+        public void CoconaApp_Run_ParameterSet()
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet>(new string[] { "--option1", "argValue0", "argValue1" });
+
+            stdOut.Should().Contain("False;argValue0;True;argValue1");
+        }
+
+        class TestCommand_ParameterSet
+        {
+            public class ParameterSet : ICommandParameterSet
+            {
+                public bool Option1 { get; set; }
+
+                [Argument]
+                public string Arg0 { get; set; }
+            }
+
+            public void Run(bool option0, ParameterSet paramSet, [Argument]string arg1)
+            {
+                Console.WriteLine($"{option0};{paramSet.Arg0};{paramSet.Option1};{arg1}");
+            }
+        }
     }
 }

--- a/test/Cocona.Test/Integration/EndToEndTest.cs
+++ b/test/Cocona.Test/Integration/EndToEndTest.cs
@@ -516,9 +516,17 @@ namespace Cocona.Test.Integration
         [Fact]
         public void CoconaApp_Run_ParameterSet()
         {
-            var (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet>(new string[] { "--option1", "argValue0", "argValue1" });
-
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet>(new string[] { "--option1", "--option-required=alice", "argValue0", "argValue1" });
+            exitCode.Should().Be(0);
             stdOut.Should().Contain("False;argValue0;True;argValue1");
+
+            (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet>(new string[] { "--help" });
+            stdOut.Should().Contain("0: arg0");
+            stdOut.Should().Contain("1: arg1");
+            stdOut.Should().Contain("--option0");
+            stdOut.Should().Contain("--option1");
+            stdOut.Should().MatchRegex(@"--option-has-default <String>\s+\(Default: hello\)");
+            stdOut.Should().MatchRegex(@"--option-required <String>\s+\(Required\)");
         }
 
         class TestCommand_ParameterSet
@@ -527,6 +535,10 @@ namespace Cocona.Test.Integration
             {
                 public bool Option1 { get; set; }
 
+                [HasDefaultValue]
+                public string OptionHasDefault { get; set; } = "hello";
+                public string OptionRequired { get; set; } = "ignored";
+
                 [Argument]
                 public string Arg0 { get; set; }
             }
@@ -534,6 +546,67 @@ namespace Cocona.Test.Integration
             public void Run(bool option0, ParameterSet paramSet, [Argument]string arg1)
             {
                 Console.WriteLine($"{option0};{paramSet.Arg0};{paramSet.Option1};{arg1}");
+            }
+        }
+
+        [Fact]
+        public void CoconaApp_Run_ParameterSet_Record()
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet_Record>(new string[] { "--option1", "--option-required=alice", "argValue0", "argValue1" });
+            exitCode.Should().Be(0);
+            stdOut.Should().Contain("False;argValue0;True;argValue1");
+
+            (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet_Record>(new string[] { "--help" });
+            stdOut.Should().Contain("0: arg0");
+            stdOut.Should().Contain("1: arg1");
+            stdOut.Should().Contain("--option0");
+            stdOut.Should().Contain("--option1");
+            stdOut.Should().MatchRegex(@"--option-required <String>\s+\(Required\)");
+            stdOut.Should().MatchRegex(@"--option-has-default <String>\s+\(Default: hello\)");
+        }
+
+        class TestCommand_ParameterSet_Record
+        {
+            public record ParameterSet(bool Option1, string OptionRequired, [Argument] string Arg0, string OptionHasDefault = "hello") : ICommandParameterSet;
+
+            public void Run(bool option0, ParameterSet paramSet, [Argument] string arg1)
+            {
+                Console.WriteLine($"{option0};{paramSet.Arg0};{paramSet.Option1};{arg1}");
+            }
+        }
+
+        [Fact]
+        public void CoconaApp_Run_ParameterSet_Record_MultipleCommand()
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet_Record_MultipleCommand>(new string[] { "command-a", "--option1", "--option-required=alice", "argValue0", "argValue1" });
+            exitCode.Should().Be(0);
+            stdOut.Should().Contain("A:False;argValue0;True;argValue1");
+
+            (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet_Record_MultipleCommand>(new string[] { "--help" });
+            stdOut.Should().Contain("command-a");
+            stdOut.Should().Contain("command-b");
+
+            (stdOut, stdErr, exitCode) = Run<TestCommand_ParameterSet_Record_MultipleCommand>(new string[] { "command-a", "--help" });
+            stdOut.Should().Contain("0: arg0");
+            stdOut.Should().Contain("1: arg1");
+            stdOut.Should().Contain("--option0");
+            stdOut.Should().Contain("--option1");
+            stdOut.Should().MatchRegex(@"--option-required <String>\s+\(Required\)");
+            stdOut.Should().MatchRegex(@"--option-has-default <String>\s+\(Default: hello\)");
+        }
+
+        class TestCommand_ParameterSet_Record_MultipleCommand
+        {
+            public record ParameterSet(bool Option1, string OptionRequired, [Argument] string Arg0, string OptionHasDefault = "hello") : ICommandParameterSet;
+
+            public void CommandA(bool option0, ParameterSet paramSet, [Argument] string arg1)
+            {
+                Console.WriteLine($"A:{option0};{paramSet.Arg0};{paramSet.Option1};{arg1}");
+            }
+
+            public void CommandB(bool option0, ParameterSet paramSet, [Argument] string arg1)
+            {
+                Console.WriteLine($"B:{option0};{paramSet.Arg0};{paramSet.Option1};{arg1}");
             }
         }
     }


### PR DESCRIPTION
Fix #29 

This PR introduces a mechanism called Parameter set that defines common parameters for multiple commands.
For example, if every command receives a user name, host name, etc., it would be annoying to define them in a method for each command.

A class or `record` implements the `ICommandParameterSet` interface and treats it as a Parameter set.

- See: [samples/InAction.ParameterSet](samples/InAction.ParameterSet)

### By parameterized constructor (includes record class)
If a class (or record class) has a parameterized constructor, it is treated as part of the definition of a command method.

```csharp
public record CommonParameters(
    [Option('t', Description = "Specifies the remote host to connect.")]
    string Host,
    [Option('p', Description = "Port to connect to on the remote host.")]
    int Port,
    [Option('u', Description = "Specifies the user to log in as on the remote host.")]
    string User = "root",
    [Option('f', Description = "Perform without user confirmation.")]
    bool Force = false
) : ICommandParameterSet;

public void Add(CommonParameters commonParams, [Argument] string from, [Argument] string to)
    => Console.WriteLine($"Add: {commonParams.User}@{commonParams.Host}:{commonParams.Port} {(commonParams.Force ? " (Force)" : "")}");

public void Update(CommonParameters commonParams, [Option('r', Description = "Traverse recursively to perform.")] bool recursive, [Argument] string path)
    => Console.WriteLine($"Update: {commonParams.User}@{commonParams.Host}:{commonParams.Port} {(commonParams.Force ? " (Force)" : "")}");
```

### By properties (parameter-less constructor)
If a class has a parameter-less constructor, you can mark the public property as `Option` or `Argument`.

**NOTE: Option defined as a property is treated as required by default. If you want a non-required Option to have a default value, mark it with `HasDefaultValue` attribute.**

```csharp
public class CommonParameters : ICommandParameterSet
{
    [Option('t', Description = "Specifies the remote host to connect.")]
    public string Host { get; set; }

    [Option('p', Description = "Port to connect to on the remote host.")]
    public int Port { get; set; }

    [Option('u', Description = "Specifies the user to log in as on the remote host.")]
    [HasDefaultValue]
    public string User  { get; set; } = "root";

    [Option('f', Description = "Perform without user confirmation.")]
    public bool Force  { get; set; } = false;
}

public void Add(CommonParameters commonParams, [Argument] string from, [Argument] string to)
    => Console.WriteLine($"Add: {commonParams.User}@{commonParams.Host}:{commonParams.Port} {(commonParams.Force ? " (Force)" : "")}");

public void Update(CommonParameters commonParams, [Option('r', Description = "Traverse recursively to perform.")] bool recursive, [Argument] string path)
    => Console.WriteLine($"Update: {commonParams.User}@{commonParams.Host}:{commonParams.Port} {(commonParams.Force ? " (Force)" : "")}");
```