### PR TITLE
Preserve the long named help option

### DIFF
--- a/src/Cocona.Core/Command/BuiltIn/BuiltInOptionLikeCommands.cs
+++ b/src/Cocona.Core/Command/BuiltIn/BuiltInOptionLikeCommands.cs
@@ -14,8 +14,27 @@ namespace Cocona.Command.BuiltIn
 {
     public class BuiltInOptionLikeCommands
     {
-        public static CommandOptionLikeCommandDescriptor Help { get; }
+        public static CommandOptionLikeCommandDescriptor HelpWithShortName { get; }
             = new CommandOptionLikeCommandDescriptor("help", new []{ 'h'}, new CommandDescriptor(
+                typeof(BuiltInOptionLikeCommands).GetMethod(nameof(ShowHelp))!,
+                nameof(ShowHelp),
+                Array.Empty<string>(),
+                "Show help message",
+                new[]
+                {
+                    new CommandServiceParameterDescriptor(typeof(ICoconaHelpMessageBuilder), "helpBuilder"),
+                    new CommandServiceParameterDescriptor(typeof(ICoconaConsoleProvider), "console"),
+                },
+                Array.Empty<CommandOptionDescriptor>(),
+                Array.Empty<CommandArgumentDescriptor>(),
+                Array.Empty<CommandOverloadDescriptor>(),
+                Array.Empty<CommandOptionLikeCommandDescriptor>(),
+                CommandFlags.IgnoreUnknownOptions,
+                null
+            ), CommandOptionFlags.None);
+
+        public static CommandOptionLikeCommandDescriptor Help { get; }
+            = new CommandOptionLikeCommandDescriptor("help", Array.Empty<char>(), new CommandDescriptor(
                 typeof(BuiltInOptionLikeCommands).GetMethod(nameof(ShowHelp))!,
                 nameof(ShowHelp),
                 Array.Empty<string>(),

--- a/src/Cocona.Core/Command/BuiltIn/CoconaBuiltInCommandProvider.cs
+++ b/src/Cocona.Core/Command/BuiltIn/CoconaBuiltInCommandProvider.cs
@@ -61,9 +61,16 @@ namespace Cocona.Command.BuiltIn
                 var allNames = new HashSet<string>(command.Options.Select(x => x.Name).Concat(command.OptionLikeCommands.Select(x => x.Name)));
                 var allShortNames = new HashSet<char>(command.Options.SelectMany(x => x.ShortName).Concat(command.OptionLikeCommands.SelectMany(x => x.ShortName)));
 
-                if (!allNames.Contains(BuiltInOptionLikeCommands.Help.Name) && !allShortNames.Overlaps(BuiltInOptionLikeCommands.Help.ShortName))
+                if (!allNames.Contains(BuiltInOptionLikeCommands.Help.Name))
                 {
-                    optionLikeCommands = optionLikeCommands.Append(BuiltInOptionLikeCommands.Help);
+                    if (allShortNames.Overlaps(BuiltInOptionLikeCommands.HelpWithShortName.ShortName))
+                    {
+                        optionLikeCommands = optionLikeCommands.Append(BuiltInOptionLikeCommands.Help);
+                    }
+                    else
+                    {
+                        optionLikeCommands = optionLikeCommands.Append(BuiltInOptionLikeCommands.HelpWithShortName);
+                    }
                 }
 
                 if (command.IsPrimaryCommand && depth == 0)

--- a/test/Cocona.Test/Command/BuiltIn/CoconaBuiltInCommandProviderTest.cs
+++ b/test/Cocona.Test/Command/BuiltIn/CoconaBuiltInCommandProviderTest.cs
@@ -43,7 +43,7 @@ namespace Cocona.Test.Command.BuiltIn
             commands.Primary.OptionLikeCommands.Should().HaveCount(4); // --completion-candidates, --completion, --help, --version
             commands.Primary.OptionLikeCommands[0].Should().Be(BuiltInOptionLikeCommands.CompletionCandidates); // CompletionCandidates option must be first.
             commands.Primary.OptionLikeCommands[1].Should().Be(BuiltInOptionLikeCommands.Completion);
-            commands.Primary.OptionLikeCommands[2].Should().Be(BuiltInOptionLikeCommands.Help);
+            commands.Primary.OptionLikeCommands[2].Should().Be(BuiltInOptionLikeCommands.HelpWithShortName);
             commands.Primary.OptionLikeCommands[3].Should().Be(BuiltInOptionLikeCommands.Version);
         }
 
@@ -55,7 +55,7 @@ namespace Cocona.Test.Command.BuiltIn
             commands.Should().NotBeNull();
             commands.Primary.Options.Should().HaveCount(0);
             commands.Primary.OptionLikeCommands.Should().HaveCount(2); // --help, --version
-            commands.Primary.OptionLikeCommands[0].Should().Be(BuiltInOptionLikeCommands.Help);
+            commands.Primary.OptionLikeCommands[0].Should().Be(BuiltInOptionLikeCommands.HelpWithShortName);
             commands.Primary.OptionLikeCommands[1].Should().Be(BuiltInOptionLikeCommands.Version);
         }
 
@@ -67,7 +67,7 @@ namespace Cocona.Test.Command.BuiltIn
             commands.Should().NotBeNull();
             commands.All[0].Options.Should().HaveCount(0);
             commands.All[0].OptionLikeCommands.Should().HaveCount(1); // --help
-            commands.All[0].OptionLikeCommands[0].Should().Be(BuiltInOptionLikeCommands.Help);
+            commands.All[0].OptionLikeCommands[0].Should().Be(BuiltInOptionLikeCommands.HelpWithShortName);
         }
 
         [Fact]
@@ -81,11 +81,30 @@ namespace Cocona.Test.Command.BuiltIn
             commands.All[0].Name.Should().Be("A_PrimaryHasVersionOption");
             commands.All[0].Options[0].Should().NotBe(BuiltInOptionLikeCommands.Version); // User-implemented --version
             commands.All[1].Name.Should().Be("B_HasShortHelpOption");
-            commands.All[1].OptionLikeCommands.Should().HaveCount(0); // -h
+            commands.All[1].OptionLikeCommands.Should().HaveCount(1); // --help
             commands.All[1].Options[0].Should().NotBe(BuiltInOptionLikeCommands.Help);  // User-implemented -h
+            commands.All[1].Options[0].Should().NotBe(BuiltInOptionLikeCommands.HelpWithShortName);  // User-implemented -h
             commands.All[2].Name.Should().Be("C_HasLongHelpOption");
-            commands.All[2].OptionLikeCommands.Should().HaveCount(0); // --help
+            commands.All[2].OptionLikeCommands.Should().HaveCount(0); // no built-in --help
             commands.All[2].Options[0].Should().NotBe(BuiltInOptionLikeCommands.Help);  // User-implemented --help
+            commands.All[2].Options[0].Should().NotBe(BuiltInOptionLikeCommands.HelpWithShortName);  // User-implemented --help
+        }
+
+        [Fact]
+        public void BuiltInOptionHelp_ShortNameUserOverwriteOption()
+        {
+            var provider = new CoconaBuiltInCommandProvider(new CoconaCommandProvider(new[] { typeof(CommandTestBuiltInHelpShortNameUserOverwriteOptionCommand) }), true);
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All[0].Options.Should().HaveCount(1); // User-implemented --version
+            commands.All[0].OptionLikeCommands.Should().HaveCount(3); // --completion-candidates, --completion, --help
+            commands.All[0].Name.Should().Be("A_PrimaryHasVersionOption");
+            commands.All[0].Options[0].Should().NotBe(BuiltInOptionLikeCommands.Version); // User-implemented --version
+
+            commands.All[1].Name.Should().Be("B_HasShortHelpOption");
+            commands.All[1].OptionLikeCommands.Should().HaveCount(1); // built-in ---help
+            commands.All[1].Options[0].Should().NotBe(BuiltInOptionLikeCommands.Help);  // User-implemented -h
+            commands.All[1].Options[0].Should().NotBe(BuiltInOptionLikeCommands.HelpWithShortName);  // User-implemented -h
         }
 
         public class CommandTestBuiltInPrimaryCommand
@@ -100,6 +119,13 @@ namespace Cocona.Test.Command.BuiltIn
             public void A_PrimaryHasVersionOption(bool version) { }
             public void B_HasShortHelpOption([Option('h')]bool _) { }
             public void C_HasLongHelpOption([Option]bool help) { }
+        }
+
+        public class CommandTestBuiltInHelpShortNameUserOverwriteOptionCommand
+        {
+            [PrimaryCommand]
+            public void A_PrimaryHasVersionOption(bool version) { }
+            public void B_HasShortHelpOption([Option('h')] bool _) { }
         }
     }
 }

--- a/test/Cocona.Test/Integration/EndToEndTest.cs
+++ b/test/Cocona.Test/Integration/EndToEndTest.cs
@@ -194,6 +194,16 @@ namespace Cocona.Test.Integration
         }
 
         [Fact]
+        public void CoconaApp_Run_Multiple_Help_Command_ShortOptionOverwrite()
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple>(new string[] { "help-short-option-overwrite", "--help" });
+
+            stdOut.Should().Contain("Usage:");
+            stdOut.Should().Contain(" help-short-option-overwrite [--host] [--help]");
+            exitCode.Should().Be(129);
+        }
+
+        [Fact]
         public void CoconaApp_Run_Multiple_Version()
         {
             var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple>(new string[] { "--version" });
@@ -362,6 +372,11 @@ namespace Cocona.Test.Integration
             public void OptionTest([Option] string name, [Option('a')]int age = 17)
             {
                 Console.WriteLine($"Hello {name} ({age})!");
+            }
+
+            public void HelpShortOptionOverwrite([Option('h')] bool host)
+            {
+                Console.WriteLine($"Host={host}");
             }
         }
 


### PR DESCRIPTION
If a short option `-h` is defined that overrides the help (`-h`), keep the long named help option (`--help`).