### PR TITLE
Register a method without class as a command

### DIFF
--- a/Cocona.sln
+++ b/Cocona.sln
@@ -85,7 +85,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Azure Pipelines", "Azure Pi
 		.azure-pipelines\build.yml = .azure-pipelines\build.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.InAction.ParameterSet", "samples\InAction.ParameterSet\CoconaSample.InAction.ParameterSet.csproj", "{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoconaSample.InAction.ParameterSet", "samples\InAction.ParameterSet\CoconaSample.InAction.ParameterSet.csproj", "{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.InAction.TopLevelStatements", "samples\InAction.TopLevelStatements\CoconaSample.InAction.TopLevelStatements.csproj", "{FE07270B-C0C7-4AE5-B59A-8393D4D54F80}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -209,6 +211,10 @@ Global
 		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE07270B-C0C7-4AE5-B59A-8393D4D54F80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE07270B-C0C7-4AE5-B59A-8393D4D54F80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE07270B-C0C7-4AE5-B59A-8393D4D54F80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE07270B-C0C7-4AE5-B59A-8393D4D54F80}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -242,6 +248,7 @@ Global
 		{F7ED9A50-845E-4A47-9F4E-A0C372082D76} = {09F6C99E-D874-4C82-90AA-A37E5BE707C4}
 		{C5099F3C-62C3-45F3-BFB9-194E0CEF55DB} = {09F6C99E-D874-4C82-90AA-A37E5BE707C4}
 		{A5F06C10-A10C-404D-B7F5-B0C90FAE87C8} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
+		{FE07270B-C0C7-4AE5-B59A-8393D4D54F80} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DBA26EF-235B-4656-A5DD-00C266A42735}

--- a/samples/InAction.TopLevelStatements/CoconaSample.InAction.TopLevelStatements.csproj
+++ b/samples/InAction.TopLevelStatements/CoconaSample.InAction.TopLevelStatements.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cocona\Cocona.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/InAction.TopLevelStatements/Program.cs
+++ b/samples/InAction.TopLevelStatements/Program.cs
@@ -19,5 +19,4 @@ static void Konnichiwa([Argument] string name)
     => Console.WriteLine($"Konnichiwa {name}!");
 #endif
 
-// TODO: args
-app.Run(Environment.GetCommandLineArgs().AsSpan(1).ToArray());
+app.Run();

--- a/samples/InAction.TopLevelStatements/Program.cs
+++ b/samples/InAction.TopLevelStatements/Program.cs
@@ -1,0 +1,23 @@
+using System;
+using Cocona;
+
+var app = CoconaApp.Create();
+
+#if NET6_0_OR_GREATER
+app.AddCommand([Command("hello")]([Argument] string name) => Console.WriteLine($"Hello {name}!"));
+app.AddCommand([Command("konnichiwa")]([Argument] string name) => Console.WriteLine($"Konnichiwa {name}!"));
+#else
+app.AddCommand((Action<string>)Hello);
+app.AddCommand((Action<string>)Konnichiwa);
+
+[Command("hello")]
+static void Hello([Argument] string name)
+    => Console.WriteLine($"Hello {name}!");
+
+[Command("konnichiwa")]
+static void Konnichiwa([Argument] string name)
+    => Console.WriteLine($"Konnichiwa {name}!");
+#endif
+
+// TODO: args
+app.Run(Environment.GetCommandLineArgs().AsSpan(1).ToArray());

--- a/src/Cocona.Core/Command/BuiltIn/BuiltInOptionLikeCommands.cs
+++ b/src/Cocona.Core/Command/BuiltIn/BuiltInOptionLikeCommands.cs
@@ -17,6 +17,7 @@ namespace Cocona.Command.BuiltIn
         public static CommandOptionLikeCommandDescriptor HelpWithShortName { get; }
             = new CommandOptionLikeCommandDescriptor("help", new []{ 'h'}, new CommandDescriptor(
                 typeof(BuiltInOptionLikeCommands).GetMethod(nameof(ShowHelp))!,
+                default,
                 nameof(ShowHelp),
                 Array.Empty<string>(),
                 "Show help message",
@@ -36,6 +37,7 @@ namespace Cocona.Command.BuiltIn
         public static CommandOptionLikeCommandDescriptor Help { get; }
             = new CommandOptionLikeCommandDescriptor("help", Array.Empty<char>(), new CommandDescriptor(
                 typeof(BuiltInOptionLikeCommands).GetMethod(nameof(ShowHelp))!,
+                default,
                 nameof(ShowHelp),
                 Array.Empty<string>(),
                 "Show help message",
@@ -55,6 +57,7 @@ namespace Cocona.Command.BuiltIn
         public static CommandOptionLikeCommandDescriptor Version { get; }
             = new CommandOptionLikeCommandDescriptor("version", Array.Empty<char>(), new CommandDescriptor(
                 typeof(BuiltInOptionLikeCommands).GetMethod(nameof(ShowVersion))!,
+                default,
                 nameof(ShowVersion),
                 Array.Empty<string>(),
                 "Show version",
@@ -75,6 +78,7 @@ namespace Cocona.Command.BuiltIn
         public static CommandOptionLikeCommandDescriptor Completion { get; }
             = new CommandOptionLikeCommandDescriptor("completion", Array.Empty<char>(), new CommandDescriptor(
                 typeof(BuiltInOptionLikeCommands).GetMethod(nameof(GenerateCompletionSource))!,
+                default,
                 nameof(GenerateCompletionSource),
                 Array.Empty<string>(),
                 "Generate a shell completion code",
@@ -99,6 +103,7 @@ namespace Cocona.Command.BuiltIn
         public static CommandOptionLikeCommandDescriptor CompletionCandidates { get; }
             = new CommandOptionLikeCommandDescriptor("completion-candidates", Array.Empty<char>(), new CommandDescriptor(
                 typeof(BuiltInOptionLikeCommands).GetMethod(nameof(GetCompletionCandidates))!,
+                default,
                 nameof(GetCompletionCandidates),
                 Array.Empty<string>(),
                 "Generate a shell completion candidates",

--- a/src/Cocona.Core/Command/BuiltIn/BuiltInPrimaryCommand.cs
+++ b/src/Cocona.Core/Command/BuiltIn/BuiltInPrimaryCommand.cs
@@ -25,6 +25,7 @@ namespace Cocona.Command.BuiltIn
         {
             return new CommandDescriptor(
                 _methodShowDefaultMessage,
+                default,
                 _methodShowDefaultMessage.Name,
                 Array.Empty<string>(),
                 description,

--- a/src/Cocona.Core/Command/BuiltIn/CoconaBuiltInCommandProvider.cs
+++ b/src/Cocona.Core/Command/BuiltIn/CoconaBuiltInCommandProvider.cs
@@ -40,6 +40,7 @@ namespace Cocona.Command.BuiltIn
                 var command = commands[i];
                 newCommands[i] = new CommandDescriptor(
                     command.Method,
+                    command.Target,
                     command.Name,
                     command.Aliases,
                     command.Description,

--- a/src/Cocona.Core/Command/CommandDescriptor.cs
+++ b/src/Cocona.Core/Command/CommandDescriptor.cs
@@ -11,6 +11,7 @@ namespace Cocona.Command
     public class CommandDescriptor
     {
         public MethodInfo Method { get; }
+        public object? Target { get; }
         public Type CommandType => Method.DeclaringType ?? throw new InvalidOperationException("The command method must be a member of the class.");
         public string Name { get; }
         public IReadOnlyList<string> Aliases { get; }
@@ -31,6 +32,7 @@ namespace Cocona.Command
 
         public CommandDescriptor(
             MethodInfo methodInfo,
+            object? target,
             string name,
             IReadOnlyList<string> aliases,
             string description,
@@ -44,6 +46,7 @@ namespace Cocona.Command
         )
         {
             Method = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+            Target = target;
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Aliases = aliases ?? throw new ArgumentNullException(nameof(aliases));
             Description = description ?? throw new ArgumentNullException(nameof(description));

--- a/src/Cocona.Core/Command/Dispatcher/CoconaCommandDispatcher.cs
+++ b/src/Cocona.Core/Command/Dispatcher/CoconaCommandDispatcher.cs
@@ -50,7 +50,11 @@ namespace Cocona.Command.Dispatcher
 
                 // Activate a command type.
                 var commandInstance = default(object);
-                if (matchedCommand.CommandType.GetConstructors().Any() && !matchedCommand.Method.IsStatic)
+                if (matchedCommand.Target is not null)
+                {
+                    commandInstance = matchedCommand.Target;
+                }
+                else if (matchedCommand.CommandType.GetConstructors().Any() && !matchedCommand.Method.IsStatic)
                 {
                     commandInstance = _activator.GetServiceOrCreateInstance(_serviceProvider, matchedCommand.CommandType);
                     if (commandInstance == null) throw new InvalidOperationException($"Unable to activate command type '{matchedCommand.CommandType.FullName}'");

--- a/src/Cocona.Core/Command/Dispatcher/CoconaCommandDispatcher.cs
+++ b/src/Cocona.Core/Command/Dispatcher/CoconaCommandDispatcher.cs
@@ -49,8 +49,12 @@ namespace Cocona.Command.Dispatcher
                 var dispatchAsync = _dispatcherPipelineBuilder.Build();
 
                 // Activate a command type.
-                var commandInstance = _activator.GetServiceOrCreateInstance(_serviceProvider, matchedCommand.CommandType);
-                if (commandInstance == null) throw new InvalidOperationException($"Unable to activate command type '{matchedCommand.CommandType.FullName}'");
+                var commandInstance = default(object);
+                if (matchedCommand.CommandType.GetConstructors().Any() && !matchedCommand.Method.IsStatic)
+                {
+                    commandInstance = _activator.GetServiceOrCreateInstance(_serviceProvider, matchedCommand.CommandType);
+                    if (commandInstance == null) throw new InvalidOperationException($"Unable to activate command type '{matchedCommand.CommandType.FullName}'");
+                }
 
                 // Set CoconaAppContext
                 _appContext.Current = new CoconaAppContext(matchedCommand, cancellationToken);

--- a/src/Cocona.Core/Command/Dispatcher/CommandDispatchContext.cs
+++ b/src/Cocona.Core/Command/Dispatcher/CommandDispatchContext.cs
@@ -10,13 +10,13 @@ namespace Cocona.Command.Dispatcher
     {
         public CommandDescriptor Command { get;}
         
-        public object CommandTarget { get; }
+        public object? CommandTarget { get; }
 
         public ParsedCommandLine ParsedCommandLine { get; }
 
         public CancellationToken CancellationToken { get; }
 
-        public CommandDispatchContext(CommandDescriptor command, ParsedCommandLine parsedCommandLine, object commandTarget, CancellationToken cancellationToken)
+        public CommandDispatchContext(CommandDescriptor command, ParsedCommandLine parsedCommandLine, object? commandTarget, CancellationToken cancellationToken)
         {
             Command = command;
             ParsedCommandLine = parsedCommandLine;

--- a/src/Cocona.Core/Command/Features/CoconaCommandFeature.cs
+++ b/src/Cocona.Core/Command/Features/CoconaCommandFeature.cs
@@ -14,16 +14,16 @@ namespace Cocona.Command.Features
 
     public class CoconaCommandFeature : ICoconaCommandFeature
     {
-        public object CommandInstance { get; }
+        public object? CommandInstance { get; }
         public CommandDescriptor Command { get; }
         public CommandCollection CommandCollection { get; }
         public IReadOnlyList<CommandDescriptor> CommandStack { get; }
 
-        public CoconaCommandFeature(CommandCollection commandCollection, CommandDescriptor commandDescriptor, IReadOnlyList<CommandDescriptor> commandStack, object commandInstance)
+        public CoconaCommandFeature(CommandCollection commandCollection, CommandDescriptor commandDescriptor, IReadOnlyList<CommandDescriptor> commandStack, object? commandInstance)
         {
             CommandCollection = commandCollection ?? throw new ArgumentNullException(nameof(commandCollection));
             Command = commandDescriptor ?? throw new ArgumentNullException(nameof(commandDescriptor));
-            CommandInstance = commandInstance ?? throw new ArgumentNullException(nameof(commandInstance));
+            CommandInstance = commandInstance;
             CommandStack = commandStack ?? throw new ArgumentNullException(nameof(commandStack));
         }
     }

--- a/src/Cocona.Core/Command/Features/CoconaCommandFeature.cs
+++ b/src/Cocona.Core/Command/Features/CoconaCommandFeature.cs
@@ -6,7 +6,7 @@ namespace Cocona.Command.Features
 {
     public interface ICoconaCommandFeature
     {
-        object CommandInstance { get; }
+        object? CommandInstance { get; }
         CommandDescriptor Command { get; }
         CommandCollection CommandCollection { get; }
         IReadOnlyList<CommandDescriptor> CommandStack { get; }

--- a/src/Cocona.Core/Filters/CoconaCommandExecutingContext.cs
+++ b/src/Cocona.Core/Filters/CoconaCommandExecutingContext.cs
@@ -1,4 +1,4 @@
-﻿using Cocona.Command;
+using Cocona.Command;
 using Cocona.CommandLine;
 using System;
 
@@ -14,7 +14,7 @@ namespace Cocona.Filters
         {
             Command = command ?? throw new ArgumentNullException(nameof(command));
             ParsedCommandLine = parsedCommandLine ?? throw new ArgumentNullException(nameof(parsedCommandLine));
-            CommandTarget = commandTarget ?? throw new ArgumentNullException(nameof(commandTarget));
+            CommandTarget = commandTarget;
         }
     }
 }

--- a/src/Cocona.Core/Filters/CoconaCommandExecutingContext.cs
+++ b/src/Cocona.Core/Filters/CoconaCommandExecutingContext.cs
@@ -8,9 +8,9 @@ namespace Cocona.Filters
     {
         public ParsedCommandLine ParsedCommandLine { get; }
         public CommandDescriptor Command { get; }
-        public object CommandTarget { get; }
+        public object? CommandTarget { get; }
 
-        public CoconaCommandExecutingContext(CommandDescriptor command, ParsedCommandLine parsedCommandLine, object commandTarget)
+        public CoconaCommandExecutingContext(CommandDescriptor command, ParsedCommandLine parsedCommandLine, object? commandTarget)
         {
             Command = command ?? throw new ArgumentNullException(nameof(command));
             ParsedCommandLine = parsedCommandLine ?? throw new ArgumentNullException(nameof(parsedCommandLine));

--- a/src/Cocona.Lite/Cocona.Lite.csproj
+++ b/src/Cocona.Lite/Cocona.Lite.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="BannedSymbols.txt" />
+    <Compile Include="..\Cocona\Hosting\CoconaAppHostBuilderExtensions.cs" Link="Lite\Hosting\CoconaAppHostBuilderExtensions.cs" />
     <Compile Include="..\Cocona\Hosting\CoconaServiceCollectionExtensions.cs" Link="Lite\Hosting\CoconaServiceCollectionExtensions.cs" />
     <None Include="..\..\docs\assets\icon.png" Pack="true" PackagePath="/" />
   </ItemGroup>

--- a/src/Cocona.Lite/CoconaLiteAppOptions.cs
+++ b/src/Cocona.Lite/CoconaLiteAppOptions.cs
@@ -37,5 +37,10 @@ namespace Cocona
         /// Gets a list of command types.
         /// </summary>
         public IList<Type> CommandTypes { get; set; } = new List<Type>();
+
+        /// <summary>
+        /// Gets a list of command methods.
+        /// </summary>
+        public IList<Delegate> CommandMethods { get; set; } = new List<Delegate>();
     }
 }

--- a/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
+++ b/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Cocona.Application;
@@ -13,6 +15,8 @@ namespace Cocona.Lite.Hosting
     public class CoconaLiteAppHostBuilder
     {
         private Action<ICoconaLiteServiceCollection>? _configureServicesDelegate;
+        private readonly List<Delegate> _targetDelegates = new List<Delegate>();
+        private readonly List<Type> _targetTypes = new List<Type>();
 
         /// <summary>
         /// Adds services to the container.
@@ -68,13 +72,62 @@ namespace Cocona.Lite.Hosting
         public Task RunAsync(string[] args, Type[] commandTypes, Action<CoconaLiteAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
             => new CoconaLiteAppHost(Build(args, commandTypes, configureOptions)).RunAsyncCore(cancellationToken);
 
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        public void Run(string[] args, Action<CoconaLiteAppOptions>? configureOptions = null)
+            => new CoconaLiteAppHost(Build(args, Array.Empty<Type>(), configureOptions)).RunAsyncCore(default).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task RunAsync(string[] args, Action<CoconaLiteAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
+            => new CoconaLiteAppHost(Build(args, Array.Empty<Type>(), configureOptions)).RunAsyncCore(cancellationToken);
+
+        /// <summary>
+        /// Add command definition delegate to Cocona.
+        /// </summary>
+        /// <param name="commandDelegate"></param>
+        /// <returns></returns>
+        public CoconaLiteAppHostBuilder AddCommand(Delegate commandDelegate)
+        {
+            _targetDelegates.Add(commandDelegate ?? throw new ArgumentNullException(nameof(commandDelegate)));
+            return this;
+        }
+
+        /// <summary>
+        /// Add the commands type to Cocona.
+        /// </summary>
+        /// <param name="commandType"></param>
+        /// <returns></returns>
+        public CoconaLiteAppHostBuilder AddCommand(Type commandType)
+        {
+            _targetTypes.Add(commandType ?? throw new ArgumentNullException(nameof(commandType)));
+            return this;
+        }
+
+        /// <summary>
+        /// Add the commands type to Cocona.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public CoconaLiteAppHostBuilder AddCommand<T>()
+            => AddCommand(typeof(T));
+
         private IServiceProvider Build(string[] args, Type[] commandTypes, Action<CoconaLiteAppOptions>? configureOptions)
         {
             var services = new CoconaLiteServiceCollection();
 
             var options = new CoconaLiteAppOptions()
             {
-                CommandTypes = commandTypes,
+                CommandTypes = _targetTypes.Concat(commandTypes).ToList(),
+                CommandMethods = _targetDelegates.ToList(),
             };
 
             configureOptions?.Invoke(options);

--- a/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
+++ b/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
@@ -5,8 +5,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Cocona.Application;
-using Cocona.Command;
-using Cocona.Command.BuiltIn;
 using Cocona.Command.Dispatcher;
 using Cocona.Command.Dispatcher.Middlewares;
 
@@ -35,26 +33,6 @@ namespace Cocona.Lite.Hosting
         /// <summary>
         /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        public void Run<T>(string[] args, Action<CoconaLiteAppOptions>? configureOptions = null)
-            => Run(args, new[] {typeof(T)}, configureOptions);
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Task RunAsync<T>(string[] args, Action<CoconaLiteAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
-            => RunAsync(args, new[] {typeof(T)}, configureOptions, cancellationToken);
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
         /// <param name="args"></param>
         /// <param name="commandTypes"></param>
         /// <param name="configureOptions"></param>
@@ -71,24 +49,6 @@ namespace Cocona.Lite.Hosting
         /// <returns></returns>
         public Task RunAsync(string[] args, Type[] commandTypes, Action<CoconaLiteAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
             => new CoconaLiteAppHost(Build(args, commandTypes, configureOptions)).RunAsyncCore(cancellationToken);
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        public void Run(string[] args, Action<CoconaLiteAppOptions>? configureOptions = null)
-            => new CoconaLiteAppHost(Build(args, Array.Empty<Type>(), configureOptions)).RunAsyncCore(default).GetAwaiter().GetResult();
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Task RunAsync(string[] args, Action<CoconaLiteAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
-            => new CoconaLiteAppHost(Build(args, Array.Empty<Type>(), configureOptions)).RunAsyncCore(cancellationToken);
 
         /// <summary>
         /// Add command definition delegate to Cocona.
@@ -111,14 +71,6 @@ namespace Cocona.Lite.Hosting
             _targetTypes.Add(commandType ?? throw new ArgumentNullException(nameof(commandType)));
             return this;
         }
-
-        /// <summary>
-        /// Add the commands type to Cocona.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public CoconaLiteAppHostBuilder AddCommand<T>()
-            => AddCommand(typeof(T));
 
         private IServiceProvider Build(string[] args, Type[] commandTypes, Action<CoconaLiteAppOptions>? configureOptions)
         {

--- a/src/Cocona/Hosting/CoconaAppHostBuilder.cs
+++ b/src/Cocona/Hosting/CoconaAppHostBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +17,8 @@ namespace Cocona.Hosting
     public class CoconaAppHostBuilder
     {
         private readonly IHostBuilder _builder;
+        private readonly List<Delegate> _targetDelegates = new List<Delegate>();
+        private readonly List<Type> _targetTypes = new List<Type>();
 
         public CoconaAppHostBuilder(IHostBuilder hostBuilder)
         {
@@ -80,7 +83,7 @@ namespace Cocona.Hosting
         private IHost GetBuiltHost(string[] args, Type[] types, Action<CoconaAppOptions>? configureOptions)
         {
             return _builder
-                .UseCocona(args, types)
+                .UseCocona(args, _targetTypes.Concat(types), _targetDelegates)
                 .ConfigureServices(services =>
                 {
                     if (configureOptions != null)
@@ -125,11 +128,59 @@ namespace Cocona.Hosting
         /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
         /// </summary>
         /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        public void Run(string[] args, Action<CoconaAppOptions>? configureOptions = null)
+            => GetBuiltHost(args, Array.Empty<Type>(), configureOptions).Run();
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <param name="args"></param>
         /// <param name="commandTypes"></param>
         /// <param name="configureOptions"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public Task RunAsync(string[] args, Type[] commandTypes, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
             => GetBuiltHost(args, commandTypes, configureOptions).RunAsync(cancellationToken);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task RunAsync(string[] args, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
+            => GetBuiltHost(args, Array.Empty<Type>(), configureOptions).RunAsync(cancellationToken);
+
+        /// <summary>
+        /// Add command definition delegate to Cocona.
+        /// </summary>
+        /// <param name="commandDelegate"></param>
+        /// <returns></returns>
+        public CoconaAppHostBuilder AddCommand(Delegate commandDelegate)
+        {
+            _targetDelegates.Add(commandDelegate ?? throw new ArgumentNullException(nameof(commandDelegate)));
+            return this;
+        }
+
+        /// <summary>
+        /// Add the commands type to Cocona.
+        /// </summary>
+        /// <param name="commandType"></param>
+        /// <returns></returns>
+        public CoconaAppHostBuilder AddCommand(Type commandType)
+        {
+            _targetTypes.Add(commandType ?? throw new ArgumentNullException(nameof(commandType)));
+            return this;
+        }
+
+        /// <summary>
+        /// Add the commands type to Cocona.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public CoconaAppHostBuilder AddCommand<T>()
+            => AddCommand(typeof(T));
     }
 }

--- a/src/Cocona/Hosting/CoconaAppHostBuilder.cs
+++ b/src/Cocona/Hosting/CoconaAppHostBuilder.cs
@@ -98,39 +98,11 @@ namespace Cocona.Hosting
         /// <summary>
         /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        public void Run<T>(string[] args, Action<CoconaAppOptions>? configureOptions = null)
-            => Run(args, new[] { typeof(T) }, configureOptions);
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Task RunAsync<T>(string[] args, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
-            => RunAsync(args, new[] { typeof(T) }, configureOptions, cancellationToken);
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
         /// <param name="args"></param>
         /// <param name="commandTypes"></param>
         /// <param name="configureOptions"></param>
         public void Run(string[] args, Type[] commandTypes, Action<CoconaAppOptions>? configureOptions = null)
             => GetBuiltHost(args, commandTypes, configureOptions).Run();
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        public void Run(string[] args, Action<CoconaAppOptions>? configureOptions = null)
-            => GetBuiltHost(args, Array.Empty<Type>(), configureOptions).Run();
 
         /// <summary>
         /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
@@ -142,16 +114,6 @@ namespace Cocona.Hosting
         /// <returns></returns>
         public Task RunAsync(string[] args, Type[] commandTypes, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
             => GetBuiltHost(args, commandTypes, configureOptions).RunAsync(cancellationToken);
-
-        /// <summary>
-        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
-        /// </summary>
-        /// <param name="args"></param>
-        /// <param name="configureOptions"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Task RunAsync(string[] args, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
-            => GetBuiltHost(args, Array.Empty<Type>(), configureOptions).RunAsync(cancellationToken);
 
         /// <summary>
         /// Add command definition delegate to Cocona.
@@ -174,13 +136,5 @@ namespace Cocona.Hosting
             _targetTypes.Add(commandType ?? throw new ArgumentNullException(nameof(commandType)));
             return this;
         }
-
-        /// <summary>
-        /// Add the commands type to Cocona.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public CoconaAppHostBuilder AddCommand<T>()
-            => AddCommand(typeof(T));
     }
 }

--- a/src/Cocona/Hosting/CoconaAppHostBuilderExtensions.cs
+++ b/src/Cocona/Hosting/CoconaAppHostBuilderExtensions.cs
@@ -37,6 +37,26 @@ namespace Cocona
         /// <summary>
         /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static Task RunAsync(this CoconaAppHostBuilder builder, string[] args, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
+            => builder.RunAsync(args, Array.Empty<Type>(), configureOptions, cancellationToken);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        public static void Run(this CoconaAppHostBuilder builder, string[] args, Action<CoconaAppOptions>? configureOptions = null)
+            => builder.Run(args, Array.Empty<Type>(), configureOptions);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="builder"></param>
         /// <param name="args"></param>

--- a/src/Cocona/Hosting/CoconaAppHostBuilderExtensions.cs
+++ b/src/Cocona/Hosting/CoconaAppHostBuilderExtensions.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+#if COCONA_LITE
+using CoconaAppHostBuilder = Cocona.Lite.Hosting.CoconaLiteAppHostBuilder;
+using CoconaAppOptions = Cocona.CoconaLiteAppOptions;
+using Cocona.Lite.Hosting;
+#else
+using Cocona.Hosting;
+#endif
+
+namespace Cocona
+{
+    public static class CoconaAppHostBuilderExtensions
+    {
+        /// <summary>
+        /// Add the commands type to Cocona.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static CoconaAppHostBuilder AddCommand<T>(this CoconaAppHostBuilder builder)
+            => builder.AddCommand(typeof(T));
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        public static void Run<T>(this CoconaAppHostBuilder builder, string[] args, Action<CoconaAppOptions>? configureOptions = null)
+            => builder.Run(args, new[] { typeof(T) }, configureOptions);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="args"></param>
+        /// <param name="configureOptions"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static Task RunAsync<T>(this CoconaAppHostBuilder builder, string[] args, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
+            => builder.RunAsync(args, new[] { typeof(T) }, configureOptions, cancellationToken);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="configureOptions"></param>
+        public static void Run<T>(this CoconaAppHostBuilder builder, Action<CoconaAppOptions>? configureOptions = null)
+            => builder.Run(GetCommandLineArguments(), new[] { typeof(T) }, configureOptions);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="configureOptions"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static Task RunAsync<T>(this CoconaAppHostBuilder builder, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
+            => builder.RunAsync(GetCommandLineArguments(), new[] { typeof(T) }, configureOptions, cancellationToken);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configureOptions"></param>
+        public static void Run(this CoconaAppHostBuilder builder, Action<CoconaAppOptions>? configureOptions = null)
+            => builder.Run(GetCommandLineArguments(), Array.Empty<Type>(), configureOptions);
+
+        /// <summary>
+        /// Builds host and starts the Cocona enabled application, and waits for Ctrl+C or SIGTERM to shutdown.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configureOptions"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static Task RunAsync(this CoconaAppHostBuilder builder, Action<CoconaAppOptions>? configureOptions = null, CancellationToken cancellationToken = default)
+            => builder.RunAsync(GetCommandLineArguments(), Array.Empty<Type>(), configureOptions, cancellationToken);
+
+        private static string[] GetCommandLineArguments()
+        {
+            var args = Environment.GetCommandLineArgs();
+            return args.Any()
+                ? args.AsSpan(1).ToArray() // args[0] is the path to executable binary.
+                : Array.Empty<string>();
+        }
+    }
+}

--- a/src/Cocona/Hosting/CoconaAppHostBuilderExtensions.cs
+++ b/src/Cocona/Hosting/CoconaAppHostBuilderExtensions.cs
@@ -88,7 +88,7 @@ namespace Cocona
         {
             var args = Environment.GetCommandLineArgs();
             return args.Any()
-                ? args.AsSpan(1).ToArray() // args[0] is the path to executable binary.
+                ? args.Skip(1).ToArray() // args[0] is the path to executable binary.
                 : Array.Empty<string>();
         }
     }

--- a/src/Cocona/Hosting/CoconaAppOptions.cs
+++ b/src/Cocona/Hosting/CoconaAppOptions.cs
@@ -38,5 +38,10 @@ namespace Cocona.Hosting
         /// Gets a list of command types.
         /// </summary>
         public IList<Type> CommandTypes { get; set; } = new List<Type>();
+
+        /// <summary>
+        /// Gets a list of command methods.
+        /// </summary>
+        public IList<Delegate> CommandMethods { get; set; } = new List<Delegate>();
     }
 }

--- a/src/Cocona/Hosting/CoconaHostBuilderExtensions.cs
+++ b/src/Cocona/Hosting/CoconaHostBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public static class CoconaHostBuilderExtensions
     {
-        public static IHostBuilder UseCocona(this IHostBuilder hostBuilder, string[] args, Type[] types)
+        public static IHostBuilder UseCocona(this IHostBuilder hostBuilder, string[] args, IEnumerable<Type> types, IEnumerable<Delegate>? methods = default)
         {
             return hostBuilder
                 .ConfigureLogging(logging =>
@@ -32,7 +32,8 @@ namespace Microsoft.Extensions.Hosting
 
                     services.Configure<CoconaAppOptions>(options =>
                     {
-                        options.CommandTypes = types;
+                        options.CommandTypes = types.ToList();
+                        options.CommandMethods = (methods ?? Array.Empty<Delegate>()).ToList();
                     });
                 });
         }

--- a/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
+++ b/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using System.Reflection;
 using Cocona;
 using Cocona.Application;
 using Cocona.Command;
@@ -51,6 +53,7 @@ namespace Microsoft.Extensions.Hosting
                 return new CoconaBuiltInCommandProvider(
                     new CoconaCommandProvider(
                         options.CommandTypes.ToArray(),
+                        Array.Empty<MethodInfo>(),
                         options.TreatPublicMethodsAsCommands,
                         options.EnableConvertOptionNameToLowerCase,
                         options.EnableConvertCommandNameToLowerCase,

--- a/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
+++ b/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.Hosting
                 return new CoconaBuiltInCommandProvider(
                     new CoconaCommandProvider(
                         options.CommandTypes.ToArray(),
-                        Array.Empty<MethodInfo>(),
+                        Array.Empty<Delegate>(),
                         options.TreatPublicMethodsAsCommands,
                         options.EnableConvertOptionNameToLowerCase,
                         options.EnableConvertCommandNameToLowerCase,

--- a/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
+++ b/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.Hosting
                 return new CoconaBuiltInCommandProvider(
                     new CoconaCommandProvider(
                         options.CommandTypes.ToArray(),
-                        Array.Empty<Delegate>(),
+                        options.CommandMethods.ToArray(),
                         options.TreatPublicMethodsAsCommands,
                         options.EnableConvertOptionNameToLowerCase,
                         options.EnableConvertCommandNameToLowerCase,

--- a/test/Cocona.Test/Command/CommandDispatcher/CommandMatcherTest.cs
+++ b/test/Cocona.Test/Command/CommandDispatcher/CommandMatcherTest.cs
@@ -21,6 +21,7 @@ namespace Cocona.Test.Command.CommandDispatcher
         {
             return new CommandDescriptor(
                 typeof(CommandMatcherTest).GetMethod(nameof(CommandMatcherTest.__Dummy), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance),
+                default,
                 name,
                 Array.Empty<string>(),
                 string.Empty,

--- a/test/Cocona.Test/Command/CommandDispatcher/DispatcherTest.cs
+++ b/test/Cocona.Test/Command/CommandDispatcher/DispatcherTest.cs
@@ -214,6 +214,62 @@ namespace Cocona.Test.Command.CommandDispatcher
         }
         
         [Fact]
+        public async Task DelegateSimpleSingleCommandDispatch()
+        {
+            var command = new TestCommandDelegate();
+            var action = new Action<string>(command.Test);
+
+            var services = CreateDefaultServices<TestCommandDelegate>(new string[] { "--option0=alice" });
+            var optionDesc = new CommandOptionDescriptor(
+                typeof(string),
+                "option0",
+                Array.Empty<char>(),
+                string.Empty,
+                CoconaDefaultValue.None,
+                default,
+                CommandOptionFlags.None,
+                Array.Empty<Attribute>());
+            var commands = new[]
+            {
+                new CommandDescriptor(
+                    action.Method,
+                    action.Target,
+                    nameof(TestCommandStatic.Test),
+                    Array.Empty<string>(),
+                    string.Empty,
+                    new [] { optionDesc },
+                    new []{ optionDesc },
+                    Array.Empty<CommandArgumentDescriptor>(),
+                    Array.Empty<CommandOverloadDescriptor>(),
+                    Array.Empty<CommandOptionLikeCommandDescriptor>(),
+                    CommandFlags.Primary,
+                    default
+                )
+            };
+            services.Replace(ServiceDescriptor.Transient<ICoconaCommandProvider>(sp => new StaticCommandsCommandProvider(commands)));
+            var serviceProvider = services.BuildServiceProvider();
+
+            var dispatcher = serviceProvider.GetService<ICoconaCommandDispatcher>();
+            var result = await dispatcher.DispatchAsync();
+            command.Log[0].Should().Be($"{nameof(TestCommandDelegate.Test)}:{command.Id}:option0 -> alice");
+        }
+
+        class StaticCommandsCommandProvider : ICoconaCommandProvider
+        {
+            private readonly IReadOnlyList<CommandDescriptor> _commands;
+
+            public StaticCommandsCommandProvider(IEnumerable<CommandDescriptor> commands)
+            {
+                _commands = commands.ToArray();
+            }
+            
+            public CommandCollection GetCommandCollection()
+            {
+                return new CommandCollection(_commands);
+            }
+        }
+
+        [Fact]
         public async Task StaticSimpleSingleCommandDispatch()
         {
             // NOTE: Once TestCommand is passed instead of TestCommandStatic (Generic type parameter doesn't accept a static class)
@@ -231,6 +287,7 @@ namespace Cocona.Test.Command.CommandDispatcher
             {
                 new CommandDescriptor(
                     typeof(TestCommandStatic).GetMethod(nameof(TestCommandStatic.Test)),
+                    default,
                     nameof(TestCommandStatic.Test),
                     Array.Empty<string>(),
                     string.Empty,
@@ -249,21 +306,6 @@ namespace Cocona.Test.Command.CommandDispatcher
             var dispatcher = serviceProvider.GetService<ICoconaCommandDispatcher>();
             var result = await dispatcher.DispatchAsync();
             TestCommandStatic.Log[0].Should().Be($"{nameof(TestCommandStatic.Test)}:option0 -> alice");
-        }
-
-        class StaticCommandsCommandProvider : ICoconaCommandProvider
-        {
-            private readonly IReadOnlyList<CommandDescriptor> _commands;
-
-            public StaticCommandsCommandProvider(IEnumerable<CommandDescriptor> commands)
-            {
-                _commands = commands.ToArray();
-            }
-            
-            public CommandCollection GetCommandCollection()
-            {
-                return new CommandCollection(_commands);
-            }
         }
 
         public class NoCommand
@@ -388,5 +430,18 @@ namespace Cocona.Test.Command.CommandDispatcher
                 Log.Add($"{nameof(TestCommandStatic.Test)}:{nameof(option0)} -> {option0}");
             }
         }
+
+        public class TestCommandDelegate
+        {
+            public List<string> Log { get; } = new List<string>();
+
+            public Guid Id { get; } = Guid.NewGuid();
+
+            public void Test(string option0)
+            {
+                Log.Add($"{nameof(TestCommandDelegate.Test)}:{Id}:{nameof(option0)} -> {option0}");
+            }
+        }
+
     }
 }

--- a/test/Cocona.Test/Command/CommandDispatcher/DispatcherTest.cs
+++ b/test/Cocona.Test/Command/CommandDispatcher/DispatcherTest.cs
@@ -9,9 +9,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Cocona.Command.Binder.Validation;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace Cocona.Test.Command.CommandDispatcher
@@ -210,6 +212,59 @@ namespace Cocona.Test.Command.CommandDispatcher
             nestedCommandNested.Log.Should().BeEmpty();
             nestedCommandNested2.Log.Should().Contain("C");
         }
+        
+        [Fact]
+        public async Task StaticSimpleSingleCommandDispatch()
+        {
+            // NOTE: Once TestCommand is passed instead of TestCommandStatic (Generic type parameter doesn't accept a static class)
+            var services = CreateDefaultServices<TestCommand>(new string[] { "--option0=alice" });
+            var optionDesc = new CommandOptionDescriptor(
+                typeof(string),
+                "option0",
+                Array.Empty<char>(),
+                string.Empty,
+                CoconaDefaultValue.None,
+                default,
+                CommandOptionFlags.None,
+                Array.Empty<Attribute>());
+            var commands = new[]
+            {
+                new CommandDescriptor(
+                    typeof(TestCommandStatic).GetMethod(nameof(TestCommandStatic.Test)),
+                    nameof(TestCommandStatic.Test),
+                    Array.Empty<string>(),
+                    string.Empty,
+                    new [] { optionDesc },
+                    new []{ optionDesc },
+                    Array.Empty<CommandArgumentDescriptor>(),
+                    Array.Empty<CommandOverloadDescriptor>(),
+                    Array.Empty<CommandOptionLikeCommandDescriptor>(),
+                    CommandFlags.Primary,
+                    default
+                )
+            };
+            services.Replace(ServiceDescriptor.Transient<ICoconaCommandProvider>(sp => new StaticCommandsCommandProvider(commands)));
+            var serviceProvider = services.BuildServiceProvider();
+
+            var dispatcher = serviceProvider.GetService<ICoconaCommandDispatcher>();
+            var result = await dispatcher.DispatchAsync();
+            TestCommandStatic.Log[0].Should().Be($"{nameof(TestCommandStatic.Test)}:option0 -> alice");
+        }
+
+        class StaticCommandsCommandProvider : ICoconaCommandProvider
+        {
+            private readonly IReadOnlyList<CommandDescriptor> _commands;
+
+            public StaticCommandsCommandProvider(IEnumerable<CommandDescriptor> commands)
+            {
+                _commands = commands.ToArray();
+            }
+            
+            public CommandCollection GetCommandCollection()
+            {
+                return new CommandCollection(_commands);
+            }
+        }
 
         public class NoCommand
         { }
@@ -319,6 +374,18 @@ namespace Cocona.Test.Command.CommandDispatcher
 
                 public void C() => Log.Add($"{nameof(TestDeepNestedCommand_Nested_2.C)}");
                 public void Dummy() { }
+            }
+        }
+        
+        
+        public static class TestCommandStatic
+        {
+            public static List<string> Log { get; } = new List<string>();
+
+            public static void Test(string option0)
+            {
+                Log.Clear();
+                Log.Add($"{nameof(TestCommandStatic.Test)}:{nameof(option0)} -> {option0}");
             }
         }
     }

--- a/test/Cocona.Test/Command/CommandProvider/CommandOptionDescriptorTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CommandOptionDescriptorTest.cs
@@ -13,28 +13,28 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void ValueName_NotArray()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_NotArray)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_NotArray)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             command.Options[0].ValueName.Should().Be("String");
         }
 
         [Fact]
         public void ValueName_Array()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_Array)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_Array)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             command.Options[0].ValueName.Should().Be("String");
         }
 
         [Fact]
         public void ValueName_IEnumerable()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_IEnumerable)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_IEnumerable)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             command.Options[0].ValueName.Should().Be("String");
         }
 
         [Fact]
         public void ValueName_Custom()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_Custom)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ValueName_Custom)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             command.Options[0].ValueName.Should().Be("ValueName0");
         }
 

--- a/test/Cocona.Test/Command/CommandProvider/CommandParameterSetTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CommandParameterSetTest.cs
@@ -18,7 +18,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void ParameterSet()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
 
             command.Parameters.Should().HaveCount(1);
             command.Options.Should().NotBeEmpty();
@@ -33,7 +33,7 @@ namespace Cocona.Test.Command.CommandProvider
         {
             Assert.Throws<CoconaException>(() =>
             {
-                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Option)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Option)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
         }
         [Fact]
@@ -41,7 +41,7 @@ namespace Cocona.Test.Command.CommandProvider
         {
             Assert.Throws<CoconaException>(() =>
             {
-                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Argument)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Argument)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
         }
 
@@ -50,7 +50,7 @@ namespace Cocona.Test.Command.CommandProvider
         {
             Assert.Throws<CoconaException>(() =>
             {
-                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.OptionWithParameterSet_Duplicated)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.OptionWithParameterSet_Duplicated)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
         }
 
@@ -58,13 +58,13 @@ namespace Cocona.Test.Command.CommandProvider
         public void Duplicated_Option_Argument()
         {
             // Arguments can be declared multiple times.
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ArgumentWithParameterSet_Duplicated)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ArgumentWithParameterSet_Duplicated)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
         }
 
         [Fact]
         public void Record()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Record)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Record)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
 
             command.Parameters.Should().HaveCount(1);
             command.Options.Should().NotBeEmpty();
@@ -76,14 +76,14 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void ClassIsNotMarkedAsParameterSet()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_NotICommandParameterSet)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_NotICommandParameterSet)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             command.Parameters[0].Should().NotBeOfType<CommandParameterSetDescriptor>();
         }
 
         [Fact]
         public void DefaultValue()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_DefaultValue)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_DefaultValue)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             command.Parameters[0].Should().BeOfType<CommandParameterSetDescriptor>();
 
             var paramSetDesc = ((CommandParameterSetDescriptor)command.Parameters[0]);
@@ -112,7 +112,7 @@ namespace Cocona.Test.Command.CommandProvider
         {
             Assert.Throws<CoconaException>(() =>
             {
-                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_AmbiguousConstructor)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_AmbiguousConstructor)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
         }
 
@@ -121,7 +121,7 @@ namespace Cocona.Test.Command.CommandProvider
         {
             Assert.Throws<CoconaException>(() =>
             {
-                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_NoPublicParameterlessConstructor)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_NoPublicParameterlessConstructor)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
         }
 
@@ -130,18 +130,18 @@ namespace Cocona.Test.Command.CommandProvider
         {
             Assert.Throws<CoconaException>(() =>
             {
-                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Abstract)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Abstract)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
             Assert.Throws<CoconaException>(() =>
             {
-                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Interface)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Interface)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
         }
 
         [Fact]
         public void Inheritance()
         {
-            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Inheritance)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var command = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.ParameterSet_Inheritance)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
 
             command.Parameters.Should().HaveCount(1);
             command.Options.Should().NotBeEmpty();

--- a/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
@@ -15,7 +15,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_NoOptions_NoArguments_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_NoOptions_NoArguments_NoReturn));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().BeEmpty();
@@ -26,7 +26,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_NoOptions_NoArguments_ReturnInt()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnInt)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnInt)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnInt));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().BeEmpty();
@@ -37,7 +37,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_NoOptions_NoArguments_ReturnTaskOfInt()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnTaskOfInt)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnTaskOfInt)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnTaskOfInt));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().BeEmpty();
@@ -48,7 +48,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_NoOptions_NoArguments_ReturnValueTaskOfInt()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnValueTaskOfInt)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnValueTaskOfInt)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnValueTaskOfInt));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().BeEmpty();
@@ -59,7 +59,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_NoOptions_NoArguments_ReturnString()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnString)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnString)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_NoOptions_NoArguments_ReturnString));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().BeEmpty();
@@ -70,7 +70,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_ImplicitOptions1_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_ImplicitOptions1_NoReturn));
             cmd.Options.Should().HaveCount(1);
             cmd.Options[0].Name.Should().Be("option0");
@@ -85,7 +85,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_ImplicitOptions1WithDefaultValue_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1WithDefaultValue_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1WithDefaultValue_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_ImplicitOptions1WithDefaultValue_NoReturn));
             cmd.Options.Should().HaveCount(3);
             cmd.Options[0].Name.Should().Be("option0");
@@ -111,7 +111,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_ImplicitOptions1_ExplicitOptions1_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1_NoReturn));
             cmd.Options.Should().HaveCount(2);
             cmd.Options[0].Name.Should().Be("option0");
@@ -130,7 +130,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_ImplicitOptions1_ExplicitOptions1HasShortName_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasShortName_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasShortName_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasShortName_NoReturn));
             cmd.Options.Should().HaveCount(2);
             cmd.Options[0].Name.Should().Be("option0");
@@ -150,7 +150,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_ImplicitOptions1_ExplicitOptions1HasName_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasName_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasName_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasName_NoReturn));
             cmd.Options.Should().HaveCount(2);
             cmd.Options[0].Name.Should().Be("option0");
@@ -170,7 +170,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_ImplicitOptions1_ExplicitOptions1HasNameAndDescription_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasNameAndDescription_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasNameAndDescription_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasNameAndDescription_NoReturn));
             cmd.Options.Should().HaveCount(2);
             cmd.Options[0].Name.Should().Be("option0");
@@ -190,7 +190,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_ImplicitOptions1_ExplicitOptions1HasDescription_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasDescription_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasDescription_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_ImplicitOptions1_ExplicitOptions1HasDescription_NoReturn));
             cmd.Options.Should().HaveCount(2);
             cmd.Options[0].Name.Should().Be("option0");
@@ -211,7 +211,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_Options1_Arguments1_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Options1_Arguments1_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Options1_Arguments1_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_Options1_Arguments1_NoReturn));
             cmd.Options.Should().HaveCount(1);
             cmd.Options[0].Name.Should().Be("option0");
@@ -230,7 +230,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_Options1_Arguments2_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Options1_Arguments2_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Options1_Arguments2_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_Options1_Arguments2_NoReturn));
             cmd.Options.Should().HaveCount(1);
             cmd.Options[0].Name.Should().Be("option0");
@@ -253,7 +253,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_Arguments_HasArray_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_HasArray_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_HasArray_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_Arguments_HasArray_NoReturn));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().HaveCount(2);
@@ -273,7 +273,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_Arguments_WithDefaultValue_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_WithDefaultValue_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_WithDefaultValue_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_Arguments_WithDefaultValue_NoReturn));
             cmd.Options.Should().HaveCount(1);
             cmd.Options[0].Name.Should().Be("option0");
@@ -299,7 +299,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_Arguments_HasDescription_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_HasDescription_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_HasDescription_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_Arguments_HasDescription_NoReturn));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().HaveCount(1);
@@ -315,7 +315,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_Arguments_HasName_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_HasName_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_HasName_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_Arguments_HasName_NoReturn));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().HaveCount(1);
@@ -330,7 +330,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_Arguments_Ordered_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_Ordered_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_Ordered_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_Arguments_Ordered_NoReturn));
             cmd.Options.Should().BeEmpty();
             cmd.Arguments.Should().HaveCount(2);
@@ -349,7 +349,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_HasIgnoreParameter_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_HasIgnoreParameter_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_HasIgnoreParameter_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_HasIgnoreParameter_NoReturn));
             cmd.Parameters.Should().HaveCount(3);
             cmd.Options.Should().HaveCount(1);
@@ -361,7 +361,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Default_TreatBooleanOptionAsDefaultFalse_NoReturn()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_TreatBooleanOptionAsDefaultFalse_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_TreatBooleanOptionAsDefaultFalse_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_TreatBooleanOptionAsDefaultFalse_NoReturn));
             cmd.Parameters.Should().HaveCount(1);
             cmd.Options.Should().HaveCount(1);
@@ -375,20 +375,20 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Invalid_SameOptionName()
         {
-            Assert.Throws<CoconaException>(() => new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Invalid_SameOptionName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>()));
+            Assert.Throws<CoconaException>(() => new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Invalid_SameOptionName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default));
         }
 
         [Fact]
         public void Invalid_SameOptionShortName()
         {
-            Assert.Throws<CoconaException>(() => new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Invalid_SameOptionShortName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>()));
+            Assert.Throws<CoconaException>(() => new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Invalid_SameOptionShortName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default));
         }
 
 
         [Fact]
         public void DefaultCommandFlags()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_NoOptions_NoArguments_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Default_NoOptions_NoArguments_NoReturn));
             cmd.Flags.Should().NotHaveFlag(CommandFlags.Hidden);
             cmd.Flags.Should().NotHaveFlag(CommandFlags.SubCommandsEntryPoint);
@@ -399,7 +399,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void IgnoreUnknownOptions()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.IgnoreUnknownOptions)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.IgnoreUnknownOptions)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.IgnoreUnknownOptions));
             cmd.Flags.Should().HaveFlag(CommandFlags.IgnoreUnknownOptions);
         }
@@ -407,7 +407,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void IgnoreUnknownOptions_ClassLevel()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest_IgnoreUnknownOptions>(nameof(CommandTest_IgnoreUnknownOptions.IgnoreUnknownOptions)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest_IgnoreUnknownOptions>(nameof(CommandTest_IgnoreUnknownOptions.IgnoreUnknownOptions)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.IgnoreUnknownOptions));
             cmd.Flags.Should().HaveFlag(CommandFlags.IgnoreUnknownOptions);
         }
@@ -415,7 +415,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Hidden()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Hidden)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Hidden)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.Hidden));
             cmd.Flags.Should().HaveFlag(CommandFlags.Hidden);
         }
@@ -423,7 +423,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void HasOptionLikeCommands()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.HasOptionLikeCommands)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.HasOptionLikeCommands)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.HasOptionLikeCommands));
             cmd.OptionLikeCommands.Should().HaveCount(3);
             cmd.OptionLikeCommands[0].Name.Should().Be("foo");
@@ -441,7 +441,7 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void CommandMethodForwardedTo()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandMethodForwardedTo)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandMethodForwardedTo)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be(nameof(CommandTest.CommandMethodForwardedTo));
             cmd.Description.Should().Be("CommandMethodForwardedTo-description");
             cmd.Method.Should().BeSameAs(typeof(CommandTest_CommandMethodForwardedToTarget).GetMethod(nameof(CommandTest_CommandMethodForwardedToTarget.CommandMethodForwardedToTarget)));
@@ -453,12 +453,12 @@ namespace Cocona.Test.Command.CommandProvider
         public void InvalidCommandName()
         {
             // If the command is for single-command, the name will be ignored. 
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.InvalidCommandName)), isSingleCommand:true, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.InvalidCommandName)), isSingleCommand:true, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
 
             // If the command is for multiple-command, the name must not contain invalid chars.
             Assert.Throws<CoconaException>(() =>
             {
-                var cmd2 = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.InvalidCommandName)), isSingleCommand:false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+                var cmd2 = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.InvalidCommandName)), isSingleCommand:false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             });
         }
 

--- a/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
@@ -448,6 +448,19 @@ namespace Cocona.Test.Command.CommandProvider
             cmd.Parameters.Should().HaveCount(1);
             cmd.ReturnType.Should().Be<int>();
         }
+        
+        [Fact]
+        public void InvalidCommandName()
+        {
+            // If the command is for single-command, the name will be ignored. 
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.InvalidCommandName)), isSingleCommand:true, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+
+            // If the command is for multiple-command, the name must not contain invalid chars.
+            Assert.Throws<CoconaException>(() =>
+            {
+                var cmd2 = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.InvalidCommandName)), isSingleCommand:false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            });
+        }
 
         private static MethodInfo GetMethod<T>(string methodName)
         {
@@ -496,6 +509,9 @@ namespace Cocona.Test.Command.CommandProvider
             [Command(Description = "CommandMethodForwardedTo-description")]
             [CommandMethodForwardedTo(typeof(CommandTest_CommandMethodForwardedToTarget), nameof(CommandTest_CommandMethodForwardedToTarget.CommandMethodForwardedToTarget))]
             public void CommandMethodForwardedTo() => throw new NotSupportedException();
+
+            [Command("<>")]
+            public void InvalidCommandName() => throw new NotSupportedException();
         }
 
         [IgnoreUnknownOptions]

--- a/test/Cocona.Test/Command/CommandProvider/GetCommandCollectionTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/GetCommandCollectionTest.cs
@@ -201,7 +201,74 @@ namespace Cocona.Test.Command.CommandProvider
             commands.All[0].Options[1].Flags.Should().HaveFlag(CommandOptionFlags.None);
         }
 
+        [Fact]
+        public void Static_SingleCommand()
+        {
+            var method = typeof(CommandTest_Static_SingleCommand).GetMethod("A");
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { method! });
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(1);
+            commands.All[0].Name.Should().Be("A");
+        }
+        
+        [Fact]
+        public void Static_MultipleCommands()
+        {
+            var methodA = typeof(CommandTest_Static_MultipleCommands).GetMethod("A");
+            var methodB = typeof(CommandTest_Static_MultipleCommands).GetMethod("B");
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA!, methodB! });
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(2);
+            commands.All[0].Name.Should().Be("A");
+            commands.All[1].Name.Should().Be("B");
+        }
 
+        [Fact]
+        public void Static_MultipleCommands_Delegate()
+        {
+            Func<bool, bool, int> methodA = CommandTest_Static_MultipleCommands.A;
+            Action methodB = CommandTest_Static_MultipleCommands.B;
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method, methodB.Method });
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(2);
+            commands.All[0].Name.Should().Be("A");
+            commands.All[1].Name.Should().Be("B");
+        }
+
+        [Fact]
+        public void Delegate()
+        {
+            Action<string> methodA = new CommandTestSingleCommand().A;
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method });
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(1);
+            commands.All[0].Name.Should().Be("A");
+            commands.All[0].CommandType.Should().Be<CommandTestSingleCommand>();
+        }
+
+        [Fact]
+        public void Delegate_Unnamed_Single()
+        {
+            Action<string> methodA = (string name) => {};
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method });
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(1);
+        }
+        
+        [Fact]
+        public void Delegate_Unnamed_Multiple()
+        {
+            Action<string> methodA = (string name) => {};
+            Action<string> methodB = (string name) => {};
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method, methodB.Method });
+            Assert.Throws<CoconaException>(() => provider.GetCommandCollection());
+        }
+        
         public class CommandTestDefaultPrimaryCommand_Argument
         {
             public void A([Argument]string[] args) { }
@@ -336,6 +403,17 @@ namespace Cocona.Test.Command.CommandProvider
         public class CommandTest_HiddenOption
         {
             public void A([Hidden]bool option0, bool option1) { }
+        }
+
+        public static class CommandTest_Static_SingleCommand
+        {
+            public static int A(bool option0, bool option1) => 0;
+        }
+
+        public static class CommandTest_Static_MultipleCommands
+        {
+            public static int A(bool option0, bool option1) => 0;
+            public static void B() { }
         }
     }
 }

--- a/test/Cocona.Test/Command/CommandProvider/GetCommandCollectionTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/GetCommandCollectionTest.cs
@@ -204,33 +204,20 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Static_SingleCommand()
         {
-            var method = typeof(CommandTest_Static_SingleCommand).GetMethod("A");
-            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { method! });
+            Func<bool, bool, int> methodA = CommandTest_Static_MultipleCommands.A;
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA });
             var commands = provider.GetCommandCollection();
             commands.Should().NotBeNull();
             commands.All.Should().HaveCount(1);
             commands.All[0].Name.Should().Be("A");
         }
-        
+
         [Fact]
         public void Static_MultipleCommands()
         {
-            var methodA = typeof(CommandTest_Static_MultipleCommands).GetMethod("A");
-            var methodB = typeof(CommandTest_Static_MultipleCommands).GetMethod("B");
-            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA!, methodB! });
-            var commands = provider.GetCommandCollection();
-            commands.Should().NotBeNull();
-            commands.All.Should().HaveCount(2);
-            commands.All[0].Name.Should().Be("A");
-            commands.All[1].Name.Should().Be("B");
-        }
-
-        [Fact]
-        public void Static_MultipleCommands_Delegate()
-        {
             Func<bool, bool, int> methodA = CommandTest_Static_MultipleCommands.A;
             Action methodB = CommandTest_Static_MultipleCommands.B;
-            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method, methodB.Method });
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { (Delegate)methodA, methodB });
             var commands = provider.GetCommandCollection();
             commands.Should().NotBeNull();
             commands.All.Should().HaveCount(2);
@@ -242,7 +229,7 @@ namespace Cocona.Test.Command.CommandProvider
         public void Delegate()
         {
             Action<string> methodA = new CommandTestSingleCommand().A;
-            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method });
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA });
             var commands = provider.GetCommandCollection();
             commands.Should().NotBeNull();
             commands.All.Should().HaveCount(1);
@@ -254,7 +241,7 @@ namespace Cocona.Test.Command.CommandProvider
         public void Delegate_Unnamed_Single()
         {
             Action<string> methodA = (string name) => {};
-            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method });
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA });
             var commands = provider.GetCommandCollection();
             commands.Should().NotBeNull();
             commands.All.Should().HaveCount(1);
@@ -265,7 +252,7 @@ namespace Cocona.Test.Command.CommandProvider
         {
             Action<string> methodA = (string name) => {};
             Action<string> methodB = (string name) => {};
-            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA.Method, methodB.Method });
+            var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA, methodB });
             Assert.Throws<CoconaException>(() => provider.GetCommandCollection());
         }
         

--- a/test/Cocona.Test/Command/CommandProvider/ToCommandCaseTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/ToCommandCaseTest.cs
@@ -13,7 +13,7 @@ namespace Cocona.Test.Command.BuiltIn
         [Fact]
         public void DisableCommandNameConversion()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertCommandNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertCommandNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dryRun");
             cmd.Arguments[0].Name.Should().Be("ArgName0");
@@ -21,7 +21,7 @@ namespace Cocona.Test.Command.BuiltIn
         [Fact]
         public void EnableCommandNameConversion()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertCommandNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertCommandNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be("command-name");
             cmd.Options[0].Name.Should().Be("dryRun");
             cmd.Arguments[0].Name.Should().Be("ArgName0");
@@ -29,7 +29,7 @@ namespace Cocona.Test.Command.BuiltIn
         [Fact]
         public void DisableOptionNameConversion()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertOptionNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertOptionNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dryRun");
             cmd.Arguments[0].Name.Should().Be("ArgName0");
@@ -37,7 +37,7 @@ namespace Cocona.Test.Command.BuiltIn
         [Fact]
         public void EnableOptionNameConversion()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertOptionNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertOptionNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dry-run");
             cmd.Arguments[0].Name.Should().Be("ArgName0");
@@ -45,7 +45,7 @@ namespace Cocona.Test.Command.BuiltIn
         [Fact]
         public void DisableArgumentNameConversion()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertArgumentNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertArgumentNameToLowerCase: false).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dryRun");
             cmd.Arguments[0].Name.Should().Be("ArgName0");
@@ -53,7 +53,7 @@ namespace Cocona.Test.Command.BuiltIn
         [Fact]
         public void EnableArgumentNameConversion()
         {
-            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertArgumentNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>());
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>(), enableConvertArgumentNameToLowerCase: true).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.CommandName)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
             cmd.Name.Should().Be("CommandName");
             cmd.Options[0].Name.Should().Be("dryRun");
             cmd.Arguments[0].Name.Should().Be("arg-name0");

--- a/test/Cocona.Test/Command/CommandResolver/CoconaCommandResolverTest.cs
+++ b/test/Cocona.Test/Command/CommandResolver/CoconaCommandResolverTest.cs
@@ -281,6 +281,7 @@ namespace Cocona.Test.Command.CommandResolver
             Action action = () => { };
             return new CommandOptionLikeCommandDescriptor(optionName, shortNames, new CommandDescriptor(
                 action.Method,
+                default,
                 name,
                 Array.Empty<string>(),
                 "",
@@ -309,6 +310,7 @@ namespace Cocona.Test.Command.CommandResolver
             Action action = () => { };
             return new CommandDescriptor(
                 action.Method,
+                action.Target,
                 name,
                 Array.Empty<string>(),
                 "",

--- a/test/Cocona.Test/Command/ParameterBinder/BindParameterTest.cs
+++ b/test/Cocona.Test/Command/ParameterBinder/BindParameterTest.cs
@@ -47,6 +47,7 @@ namespace Cocona.Test.Command.ParameterBinder
 
             return new CommandDescriptor(
                 typeof(BindParameterTest).GetMethod(nameof(BindParameterTest.__Dummy))!,
+                default,
                 "Test",
                 Array.Empty<string>(),
                 "",

--- a/test/Cocona.Test/Command/ParameterBinder/ParameterValidationTest.cs
+++ b/test/Cocona.Test/Command/ParameterBinder/ParameterValidationTest.cs
@@ -19,6 +19,7 @@ namespace Cocona.Test.Command.ParameterBinder
         {
             return new CommandDescriptor(
                 typeof(CommandParameterValidationTest).GetMethod(nameof(CommandParameterValidationTest.Dummy)),
+                default,
                 "Test",
                 Array.Empty<string>(),
                 "",

--- a/test/Cocona.Test/Help/CoconaCommandHelpProviderTest.cs
+++ b/test/Cocona.Test/Help/CoconaCommandHelpProviderTest.cs
@@ -34,6 +34,7 @@ namespace Cocona.Test.Help
         {
             return new CommandDescriptor(
                 typeof(CoconaCommandHelpProviderTest).GetMethod(nameof(CoconaCommandHelpProviderTest.__Dummy), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance),
+                default,
                 name,
                 Array.Empty<string>(),
                 description,

--- a/test/Cocona.Test/Help/CoconaCommandHelpProviderTransformTest.cs
+++ b/test/Cocona.Test/Help/CoconaCommandHelpProviderTransformTest.cs
@@ -45,6 +45,7 @@ namespace Cocona.Test.Help
         {
             return new CommandDescriptor(
                 typeof(T).GetMethod(methodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance),
+                default,
                 methodName,
                 Array.Empty<string>(),
                 "command description",


### PR DESCRIPTION
This PR allow static method and unnamed delegate to run.

```csharp
using System;
using Cocona;

var app = CoconaApp.Create();

app.AddCommand((Action<string>)Hello);
app.AddCommand((Action<string>)Konnichiwa);

[Command("hello")]
static void Hello([Argument] string name)
    => Console.WriteLine($"Hello {name}!");

[Command("konnichiwa")]
static void Konnichiwa([Argument] string name)
    => Console.WriteLine($"Konnichiwa {name}!");

app.Run();
```

```csharp
// If you are using C# 10 or greater, you can specify a lambda expression directly.
using Cocona;

var app = CoconaApp.Create();
app.AddCommand(([Argument] string name) => Console.WriteLine($"Konnichiwa {name}!"));
app.Run();
```