### PR TITLE
Handle static methods marked as commands.

### DIFF
--- a/src/Cocona.Core/Command/CoconaCommandProvider.cs
+++ b/src/Cocona.Core/Command/CoconaCommandProvider.cs
@@ -52,10 +52,13 @@ namespace Cocona.Command
                 if (type.GetCustomAttribute<IgnoreAttribute>() != null) continue;
 
                 // Command methods
-                foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+                foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
                 {
                     if (method.IsSpecialName || method.DeclaringType == typeof(object)) continue;
                     if (!_treatPublicMethodsAsCommands && !method.IsPublic) continue;
+
+                    // If the method is static, Command attribute is required.
+                    if (method.IsStatic && method.GetCustomAttribute<CommandAttribute>() is null) continue;
 
                     var implicitCommand = (_treatPublicMethodsAsCommands && method.IsPublic);
                     AddCommandMethod(method, null, implicitCommand);

--- a/test/Cocona.Test/Command/CommandProvider/GetCommandCollectionTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/GetCommandCollectionTest.cs
@@ -204,6 +204,29 @@ namespace Cocona.Test.Command.CommandProvider
         [Fact]
         public void Static_SingleCommand()
         {
+            var provider = new CoconaCommandProvider(new[] { typeof(CommandTest_Static_SingleCommand) });
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(1); // If the method has no "Command" attribute, it will be ignored.
+            commands.All[0].Name.Should().Be("A");
+        }
+
+        [Fact]
+        public void Static_MultipleCommands()
+        {
+            var provider = new CoconaCommandProvider(new[] { typeof(CommandTest_Static_MultipleCommands) });
+            var commands = provider.GetCommandCollection();
+            commands.Should().NotBeNull();
+            commands.All.Should().HaveCount(2); // If the method has no "Command" attribute, it will be ignored.
+            commands.All[0].Name.Should().Be("A");
+            commands.All[0].Method.IsStatic.Should().BeTrue();
+            commands.All[1].Name.Should().Be("B");
+            commands.All[1].Method.IsStatic.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Delegate_Static_SingleCommand()
+        {
             Func<bool, bool, int> methodA = CommandTest_Static_MultipleCommands.A;
             var provider = new CoconaCommandProvider(Array.Empty<Type>(), new[] { methodA });
             var commands = provider.GetCommandCollection();
@@ -213,7 +236,7 @@ namespace Cocona.Test.Command.CommandProvider
         }
 
         [Fact]
-        public void Static_MultipleCommands()
+        public void Delegate_Static_MultipleCommands()
         {
             Func<bool, bool, int> methodA = CommandTest_Static_MultipleCommands.A;
             Action methodB = CommandTest_Static_MultipleCommands.B;
@@ -392,15 +415,22 @@ namespace Cocona.Test.Command.CommandProvider
             public void A([Hidden]bool option0, bool option1) { }
         }
 
-        public static class CommandTest_Static_SingleCommand
+        public class CommandTest_Static_SingleCommand
         {
+            [Command]
             public static int A(bool option0, bool option1) => 0;
+
+            public static int NoCommandAttribute() => 0;
         }
 
-        public static class CommandTest_Static_MultipleCommands
+        public class CommandTest_Static_MultipleCommands
         {
+            [Command]
             public static int A(bool option0, bool option1) => 0;
+            [Command]
             public static void B() { }
+
+            public static int NoCommandAttribute() => 0;
         }
     }
 }

--- a/test/Cocona.Test/Integration/EndToEndTest.cs
+++ b/test/Cocona.Test/Integration/EndToEndTest.cs
@@ -687,5 +687,35 @@ namespace Cocona.Test.Integration
             public void InstanceCommandB()
                 => Console.WriteLine($"{nameof(InstanceCommandB)}:{Id}");
         }
+
+
+        [Fact]
+        public void CoconaApp_Run_Static_Single()
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Static_Single>(new[] { "--value", "123" });
+            stdOut.Should().Contain($"A:123");
+        }
+
+        class TestCommand_Static_Single
+        {
+            [Command]
+            public static void A(int value) => Console.WriteLine($"A:{value}");
+        }
+
+        [Fact]
+        public void CoconaApp_Run_Static_Multiple()
+        {
+            var command = new TestCommand_Delegate();
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Static_Multiple>(new[] { "b", "--value", "123" });
+            stdOut.Should().Contain($"B:123");
+        }
+
+        class TestCommand_Static_Multiple
+        {
+            [Command]
+            public static void A(int value) => Console.WriteLine($"A:{value}");
+            [Command]
+            public static void B(int value) => Console.WriteLine($"B:{value}");
+        }
     }
 }


### PR DESCRIPTION
This PR enables Cocona to handle static methods that are marked as commands.

```csharp
class Program
{
    [Command]
    public static void Foo()
        => Console.WriteLine("Foo");
}
```

### Limitation
- The method needs to be explicitly marked as a command. (`[Command]`)
- The type containing the method must be not `static` class. (`static` class is compiled as `abstract` class).