### PR TITLE
Add option parsing stop setting

### DIFF
--- a/src/Cocona.Core/Command/CoconaCommandProvider.cs
+++ b/src/Cocona.Core/Command/CoconaCommandProvider.cs
@@ -553,6 +553,7 @@ namespace Cocona.Command
                 var optionShortNames = attrSet.Option?.ShortNames ?? Array.Empty<char>();
                 var optionValueName = attrSet.Option?.ValueName ?? (DynamicListHelper.IsArrayOrEnumerableLike(type) ? DynamicListHelper.GetElementType(type) : type).Name;
                 var optionIsHidden = attrSet.Hidden != null;
+                var optionIsStopParsingOptions = attrSet.Option?.StopParsingOptions ?? false;
 
                 if (_enableConvertOptionNameToLowerCase) optionName = ToCommandCase(optionName);
 
@@ -569,7 +570,7 @@ namespace Cocona.Command
                     optionDesc,
                     defaultValue,
                     optionValueName,
-                    optionIsHidden ? CommandOptionFlags.Hidden : CommandOptionFlags.None,
+                    (optionIsHidden ? CommandOptionFlags.Hidden : CommandOptionFlags.None) | (optionIsStopParsingOptions ? CommandOptionFlags.StopParsingOptions : CommandOptionFlags.None),
                     attrSet.Attributes);
             }
 

--- a/src/Cocona.Core/Command/CommandOptionDescriptor.cs
+++ b/src/Cocona.Core/Command/CommandOptionDescriptor.cs
@@ -25,7 +25,7 @@ namespace Cocona.Command
         public IReadOnlyList<Attribute> ParameterAttributes { get; }
 
         public CommandOptionFlags Flags { get; }
-        public bool IsHidden => (Flags & CommandOptionFlags.Hidden) == CommandOptionFlags.Hidden;
+        public bool IsHidden => Flags.HasFlag(CommandOptionFlags.Hidden);
         public bool IsRequired => !DefaultValue.HasValue;
         public bool IsEnumerableLike => DynamicListHelper.IsArrayOrEnumerableLike(OptionType);
 
@@ -53,5 +53,6 @@ namespace Cocona.Command
         None = 0,
         Hidden = 1 << 0,
         OptionLikeCommand = 1 << 1,
+        StopParsingOptions = 1 << 2,
     }
 }

--- a/src/Cocona.Core/CommandLine/CoconaCommandLineParser.cs
+++ b/src/Cocona.Core/CommandLine/CoconaCommandLineParser.cs
@@ -82,6 +82,12 @@ namespace Cocona.CommandLine
                         {
                             if (option is CommandOptionDescriptor optionDesc)
                             {
+                                // If the flag has StopParsingOptions, no further options will be parsed.
+                                if (option.Flags.HasFlag(CommandOptionFlags.StopParsingOptions))
+                                {
+                                    optionsCompleted = true;
+                                }
+
                                 if (optionDesc.OptionType == typeof(bool))
                                 {
                                     // Boolean (flag)
@@ -118,6 +124,12 @@ namespace Cocona.CommandLine
                         {
                             if (option is CommandOptionDescriptor optionDesc)
                             {
+                                // If the flag has StopParsingOptions, no further options will be parsed.
+                                if (option.Flags.HasFlag(CommandOptionFlags.StopParsingOptions))
+                                {
+                                    optionsCompleted = true;
+                                }
+
                                 if (optionDesc.OptionType == typeof(bool))
                                 {
                                     // Boolean (flag)
@@ -161,6 +173,12 @@ namespace Cocona.CommandLine
                         {
                             if (option is CommandOptionDescriptor optionDesc)
                             {
+                                // If the flag has StopParsingOptions, no further options will be parsed.
+                                if (option.Flags.HasFlag(CommandOptionFlags.StopParsingOptions))
+                                {
+                                    optionsCompleted = true;
+                                }
+
                                 if (optionDesc.OptionType == typeof(bool))
                                 {
                                     // Boolean (flag)

--- a/src/Cocona.Core/OptionAttribute.cs
+++ b/src/Cocona.Core/OptionAttribute.cs
@@ -30,6 +30,11 @@ namespace Cocona
         /// </summary>
         public string? ValueName { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether or not to stop parsing options after this option on the command line.
+        /// </summary>
+        public bool StopParsingOptions { get; set; }
+
         public OptionAttribute()
         { }
 

--- a/test/Cocona.Test/CommandLine/CoconaCommandLineParserTest.cs
+++ b/test/Cocona.Test/CommandLine/CoconaCommandLineParserTest.cs
@@ -1542,5 +1542,51 @@ namespace Cocona.Test.CommandLine
             parsed.Options.Should().HaveCount(1);
             parsed.Arguments.Should().HaveCount(3); // new [] { "-b", "-c", "d" }
         }
+
+        [Fact]
+        public void StopParsingOption_Order_1()
+        {
+            var args = new string[] { "-b", "value", "--foo=value", "-c", "d" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new ICommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(string), "foo", new [] { 'a' }, "", new CoconaDefaultValue(string.Empty), CommandOptionFlags.StopParsingOptions),
+                    CreateCommandOption(typeof(string), "bar", new [] { 'b' }, "", new CoconaDefaultValue(string.Empty)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                    new CommandArgumentDescriptor(typeof(string), "arg0", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                    new CommandArgumentDescriptor(typeof(string[]), "arg1", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().NotBeEmpty();
+            parsed.Options.Should().HaveCount(2);
+            parsed.Arguments.Should().HaveCount(2); // new [] { "-c", "d" }
+        }
+
+        [Fact]
+        public void StopParsingOption_Order_2()
+        {
+            var args = new string[] { "--foo=value", "-b", "value", "-c", "d" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new ICommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(string), "foo", new [] { 'a' }, "", new CoconaDefaultValue(string.Empty), CommandOptionFlags.StopParsingOptions),
+                    CreateCommandOption(typeof(string), "bar", new [] { 'b' }, "", new CoconaDefaultValue(string.Empty)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                    new CommandArgumentDescriptor(typeof(string), "arg0", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                    new CommandArgumentDescriptor(typeof(string[]), "arg1", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().NotBeEmpty();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Arguments.Should().HaveCount(4); // new [] { "-b", "value", "-c", "d" }
+        }
     }
 }

--- a/test/Cocona.Test/CommandLine/CoconaCommandLineParserTest.cs
+++ b/test/Cocona.Test/CommandLine/CoconaCommandLineParserTest.cs
@@ -11,9 +11,9 @@ namespace Cocona.Test.CommandLine
 {
     public class CoconaCommandLineParserTest
     {
-        private CommandOptionDescriptor CreateCommandOption(Type optionType, string name, IReadOnlyList<char> shortName, string description, CoconaDefaultValue defaultValue)
+        private CommandOptionDescriptor CreateCommandOption(Type optionType, string name, IReadOnlyList<char> shortName, string description, CoconaDefaultValue defaultValue, CommandOptionFlags flags = CommandOptionFlags.None)
         {
-            return new CommandOptionDescriptor(optionType, name, shortName, description, defaultValue, null, CommandOptionFlags.None, Array.Empty<Attribute>());
+            return new CommandOptionDescriptor(optionType, name, shortName, description, defaultValue, null, flags, Array.Empty<Attribute>());
         }
 
         [Fact]
@@ -1475,6 +1475,72 @@ namespace Cocona.Test.CommandLine
             parsed.Options.Should().HaveCount(2);
             parsed.Options[1].Option.Should().BeOfType<CommandOptionLikeCommandDescriptor>();
             parsed.Arguments.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void StopParsingOption_Short()
+        {
+            var args = new string[] { "-a", "value", "-b", "-c", "d" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new ICommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(string), "foo", new [] { 'a' }, "", new CoconaDefaultValue(string.Empty), CommandOptionFlags.StopParsingOptions),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                    new CommandArgumentDescriptor(typeof(string), "arg0", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                    new CommandArgumentDescriptor(typeof(string[]), "arg1", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().NotBeEmpty();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Arguments.Should().HaveCount(3); // new [] { "-b", "-c", "d" }
+        }
+
+        [Fact]
+        public void StopParsingOption_Long()
+        {
+            var args = new string[] { "--foo", "value", "-b", "-c", "d" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new ICommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(string), "foo", new [] { 'a' }, "", new CoconaDefaultValue(string.Empty), CommandOptionFlags.StopParsingOptions),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                    new CommandArgumentDescriptor(typeof(string), "arg0", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                    new CommandArgumentDescriptor(typeof(string[]), "arg1", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().NotBeEmpty();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Arguments.Should().HaveCount(3); // new [] { "-b", "-c", "d" }
+        }
+
+        [Fact]
+        public void StopParsingOption_Long_2()
+        {
+            var args = new string[] { "--foo=value", "-b", "-c", "d" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new ICommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(string), "foo", new [] { 'a' }, "", new CoconaDefaultValue(string.Empty), CommandOptionFlags.StopParsingOptions),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                    new CommandArgumentDescriptor(typeof(string), "arg0", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                    new CommandArgumentDescriptor(typeof(string[]), "arg1", 0, "", CoconaDefaultValue.None, Array.Empty<Attribute>()),
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().NotBeEmpty();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Arguments.Should().HaveCount(3); // new [] { "-b", "-c", "d" }
         }
     }
 }

--- a/test/Cocona.Test/Integration/EndToEndTest.cs
+++ b/test/Cocona.Test/Integration/EndToEndTest.cs
@@ -717,5 +717,18 @@ namespace Cocona.Test.Integration
             [Command]
             public static void B(int value) => Console.WriteLine($"B:{value}");
         }
+
+        [Fact]
+        public void CoconaApp_Run_StopParsingOption()
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_StopParsingOption>(new[] { "--a", "123", "--b", "valueB", "A", "B", "C", "D" });
+            stdOut.Should().Contain($"A:123:valueB:A:B,C,D");
+        }
+
+        class TestCommand_StopParsingOption
+        {
+            public void A([Option]int a, [Option(StopParsingOptions = true)]string b, [Argument]string arg0, [Argument]string[] args)
+                => Console.WriteLine($"A:{a}:{b}:{arg0}:{string.Join(",", args)}");
+        }
     }
 }


### PR DESCRIPTION
This PR enables to stop parsing options after a option on a command line.

```csharp
public void A([Option]int a, [Option(StopParsingOptions = true)]string b, [Argument]string arg0, [Argument]string[] args)
{
   // $ ./myapp --a 123 --b valueB -c -d --e f
   // a = 123
   // b = "valueB"
   // arg0 = "-c"
   // args = new [] { "d", "--e", "f" }
}
```