### PR TITLE
Treats parameters of nullable type as optional

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -21,7 +21,11 @@ jobs:
         packageType: 'sdk'
         version: 6.0.x
         useGlobalJson: true
-
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        version: 3.1.x
+        useGlobalJson: true
     - script: dotnet restore
       displayName: dotnet restore
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,8 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          '3.1.x'
-          '6.0.x'
+          3.1.x
+          6.0.x
 
     # Build
     - run: dotnet restore

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+          '3.1.x'
+          '6.0.x'
 
     # Build
     - run: dotnet restore

--- a/samples/MinimalApi.InAction/Program.cs
+++ b/samples/MinimalApi.InAction/Program.cs
@@ -17,6 +17,13 @@ app.AddCommand("hello", (string name) => Console.WriteLine($"Hello {name}"))
     .WithDescription("Say hello")
     .WithAliases("hey", "konnichiwa");
 
+// Add a command with non-mandatory option and argument.
+// If a method parameter is nullable, it will be treated as non-mandatory.
+app.AddCommand("optional-param", (int? age, [Argument]string? name) =>
+{
+    Console.WriteLine($"Hello {(name ?? "Guest")} ({(age?.ToString() ?? "-")})!");
+});
+
 // Add a command and use the context to cancel with Ctrl+C.
 app.AddCommand("long-running", async (CoconaAppContext ctx) =>
 {

--- a/src/Cocona.Core/Command/CoconaCommandProvider.cs
+++ b/src/Cocona.Core/Command/CoconaCommandProvider.cs
@@ -648,7 +648,7 @@ namespace Cocona.Command
                 var optionName = attrSet.Option?.Name ?? name;
                 var optionDesc = attrSet.Option?.Description ?? string.Empty;
                 var optionShortNames = attrSet.Option?.ShortNames ?? Array.Empty<char>();
-                var optionValueName = attrSet.Option?.ValueName ?? (DynamicListHelper.IsArrayOrEnumerableLike(type) ? DynamicListHelper.GetElementType(type) : type).Name;
+                var optionValueName = attrSet.Option?.ValueName;
                 var optionIsHidden = attrSet.Hidden != null;
                 var optionIsStopParsingOptions = attrSet.Option?.StopParsingOptions ?? false;
 

--- a/src/Cocona.Core/Command/CommandArgumentDescriptor.cs
+++ b/src/Cocona.Core/Command/CommandArgumentDescriptor.cs
@@ -9,18 +9,24 @@ namespace Cocona.Command
     public class CommandArgumentDescriptor : ICommandParameterDescriptor
     {
         public Type ArgumentType { get; }
+        public Type UnwrappedArgumentType { get; } // ArgumentType = Nullable<bool> --> UnwrappedArgumentType = bool
         public string Name { get; }
         public int Order { get; }
         public string Description { get; }
         public CoconaDefaultValue DefaultValue { get; }
         public IReadOnlyList<Attribute> ParameterAttributes { get; }
 
-        public bool IsEnumerableLike => DynamicListHelper.IsArrayOrEnumerableLike(ArgumentType);
+        public bool IsEnumerableLike => DynamicListHelper.IsArrayOrEnumerableLike(UnwrappedArgumentType);
         public bool IsRequired => !DefaultValue.HasValue;
+        
 
         public CommandArgumentDescriptor(Type argumentType, string name, int order, string description, CoconaDefaultValue defaultValue, IReadOnlyList<Attribute> parameterAttributes)
         {
             ArgumentType = argumentType ?? throw new ArgumentNullException(nameof(argumentType));
+            UnwrappedArgumentType = argumentType.IsValueType && argumentType.IsConstructedGenericType && argumentType.GetGenericTypeDefinition() == typeof(Nullable<>)
+                ? argumentType.GetGenericArguments()[0]
+                : argumentType;
+
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Order = order;
             Description = description ?? throw new ArgumentNullException(nameof(description));

--- a/src/Cocona.Core/CommandLine/CoconaCommandLineParser.cs
+++ b/src/Cocona.Core/CommandLine/CoconaCommandLineParser.cs
@@ -88,7 +88,7 @@ namespace Cocona.CommandLine
                                     optionsCompleted = true;
                                 }
 
-                                if (optionDesc.OptionType == typeof(bool))
+                                if (optionDesc.OptionType == typeof(bool) || optionDesc.OptionType == typeof(bool?))
                                 {
                                     // Boolean (flag)
                                     var flag = string.Equals(partRight, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(partRight, "1", StringComparison.OrdinalIgnoreCase)
@@ -130,7 +130,7 @@ namespace Cocona.CommandLine
                                     optionsCompleted = true;
                                 }
 
-                                if (optionDesc.OptionType == typeof(bool))
+                                if (optionDesc.OptionType == typeof(bool) || optionDesc.OptionType == typeof(bool?))
                                 {
                                     // Boolean (flag)
                                     options.Add(new CommandOption(optionDesc, "true", i));
@@ -179,7 +179,7 @@ namespace Cocona.CommandLine
                                     optionsCompleted = true;
                                 }
 
-                                if (optionDesc.OptionType == typeof(bool))
+                                if (optionDesc.OptionType == typeof(bool) || optionDesc.OptionType == typeof(bool?))
                                 {
                                     // Boolean (flag)
                                     options.Add(new CommandOption(optionDesc, "true", i));

--- a/src/Cocona.Core/CommandLine/CoconaCommandLineParser.cs
+++ b/src/Cocona.Core/CommandLine/CoconaCommandLineParser.cs
@@ -88,7 +88,7 @@ namespace Cocona.CommandLine
                                     optionsCompleted = true;
                                 }
 
-                                if (optionDesc.OptionType == typeof(bool) || optionDesc.OptionType == typeof(bool?))
+                                if (optionDesc.UnwrappedOptionType == typeof(bool))
                                 {
                                     // Boolean (flag)
                                     var flag = string.Equals(partRight, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(partRight, "1", StringComparison.OrdinalIgnoreCase)
@@ -130,7 +130,7 @@ namespace Cocona.CommandLine
                                     optionsCompleted = true;
                                 }
 
-                                if (optionDesc.OptionType == typeof(bool) || optionDesc.OptionType == typeof(bool?))
+                                if (optionDesc.UnwrappedOptionType == typeof(bool))
                                 {
                                     // Boolean (flag)
                                     options.Add(new CommandOption(optionDesc, "true", i));
@@ -179,7 +179,7 @@ namespace Cocona.CommandLine
                                     optionsCompleted = true;
                                 }
 
-                                if (optionDesc.OptionType == typeof(bool) || optionDesc.OptionType == typeof(bool?))
+                                if (optionDesc.UnwrappedOptionType == typeof(bool))
                                 {
                                     // Boolean (flag)
                                     options.Add(new CommandOption(optionDesc, "true", i));

--- a/src/Cocona.Core/Help/CoconaCommandHelpProvider.cs
+++ b/src/Cocona.Core/Help/CoconaCommandHelpProvider.cs
@@ -48,7 +48,7 @@ namespace Cocona.Help
                 foreach (var opt in command.Options.Where(x => !x.IsHidden))
                 {
                     sb.Append(" ");
-                    if (opt.OptionType == typeof(bool))
+                    if (opt.UnwrappedOptionType == typeof(bool))
                     {
                         if (opt.DefaultValue.HasValue && opt.DefaultValue.Value != null && opt.DefaultValue.Value.Equals(true))
                         {
@@ -230,7 +230,7 @@ namespace Cocona.Help
                                 .Select((x, i) =>
                                     new HelpLabelDescriptionListItem(
                                         $"{i}: {x.Name}",
-                                        BuildParameterDescription(_localizer.GetArgumentDescription(command, x), x.IsRequired, x.ArgumentType, x.DefaultValue)
+                                        BuildParameterDescription(_localizer.GetArgumentDescription(command, x), x.IsRequired, x.UnwrappedArgumentType, x.DefaultValue)
                                     )
                                 )
                                 .ToArray()
@@ -254,7 +254,7 @@ namespace Cocona.Help
                                     x is CommandOptionDescriptor option
                                         ? new HelpLabelDescriptionListItem(
                                             BuildParameterLabel(option),
-                                            BuildParameterDescription(_localizer.GetOptionDescription(command, x), option.IsRequired, option.OptionType, option.DefaultValue)
+                                            BuildParameterDescription(_localizer.GetOptionDescription(command, x), option.IsRequired, option.UnwrappedOptionType, option.DefaultValue)
                                         )
                                         : x is CommandOptionLikeCommandDescriptor optionLikeCommand
                                             ? new HelpLabelDescriptionListItem(
@@ -275,7 +275,7 @@ namespace Cocona.Help
             return (option.ShortName.Any() ? string.Join(", ", option.ShortName.Select(x => $"-{x}")) + ", " : "") +
                 $"--{option.Name}" +
                 (
-                    option.OptionType == typeof(bool)
+                    option.UnwrappedOptionType == typeof(bool)
                         ? option.DefaultValue.HasValue && option.DefaultValue.Value != null && option.DefaultValue.Value.Equals(true)
                             ? "=<true|false>"
                             : ""

--- a/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
+++ b/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
@@ -27,6 +27,12 @@ namespace Cocona.Internal
 #else
         public NullabilityState GetNullabilityState(ParameterInfo parameterInfo)
         {
+            return GetNullabilityState_Compat(parameterInfo);
+        }
+#endif
+
+        internal NullabilityState GetNullabilityState_Compat(ParameterInfo parameterInfo)
+        {
             if (parameterInfo.ParameterType.IsValueType)
             {
                 if (parameterInfo.ParameterType.IsConstructedGenericType && parameterInfo.ParameterType.GetGenericTypeDefinition() == typeof(Nullable<>))
@@ -39,16 +45,47 @@ namespace Cocona.Internal
                 }
             }
 
+            // NullableAttribute on the parameter.
             foreach (var attr in parameterInfo.GetCustomAttributesData())
             {
                 if (attr.AttributeType is { Namespace: "System.Runtime.CompilerServices", Name: "NullableAttribute" })
                 {
-                    return (NullabilityState)((byte)attr.ConstructorArguments[0].Value!);
+                    return (NullabilityState)GetFirstByte(attr.ConstructorArguments[0].Value!);
+                }
+            }
+
+            // NullableContextAttribute on the member
+            foreach (var attr in parameterInfo.Member.GetCustomAttributesData())
+            {
+                if (attr.AttributeType is { Namespace: "System.Runtime.CompilerServices", Name: "NullableContextAttribute" })
+                {
+                    return (NullabilityState)GetFirstByte(attr.ConstructorArguments[0].Value!);
+                }
+            }
+
+            // NullableContextAttribute on the declaring type
+            if (parameterInfo.Member.DeclaringType is not null)
+            {
+                foreach (var attr in parameterInfo.Member.DeclaringType.GetCustomAttributesData())
+                {
+                    if (attr.AttributeType is { Namespace: "System.Runtime.CompilerServices", Name: "NullableContextAttribute" })
+                    {
+                        return (NullabilityState)GetFirstByte(attr.ConstructorArguments[0].Value!);
+                    }
                 }
             }
 
             return NullabilityState.Unknown;
+
+            static byte GetFirstByte(object? attrCtorArg)
+            {
+                return attrCtorArg switch
+                {
+                    byte x => x,
+                    IReadOnlyCollection<CustomAttributeTypedArgument> x => (byte)x.First().Value!,
+                    _ => throw new NotSupportedException(),
+                };
+            }
         }
-#endif
     }
 }

--- a/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
+++ b/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
@@ -27,6 +27,18 @@ namespace Cocona.Internal
 #else
         public NullabilityState GetNullabilityState(ParameterInfo parameterInfo)
         {
+            if (parameterInfo.ParameterType.IsValueType)
+            {
+                if (parameterInfo.ParameterType.IsConstructedGenericType && parameterInfo.ParameterType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    return NullabilityState.Nullable;
+                }
+                else
+                {
+                    return NullabilityState.NotNull;
+                }
+            }
+
             foreach (var attr in parameterInfo.GetCustomAttributesData())
             {
                 if (attr.AttributeType is { Namespace: "System.Runtime.CompilerServices", Name: "NullableAttribute" })

--- a/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
+++ b/src/Cocona.Core/Internal/NullabilityInfoContextHelper.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cocona.Internal
+{
+    internal class NullabilityInfoContextHelper
+    {
+        // see: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.nullabilitystate?view=net-6.0
+        public enum NullabilityState
+        {
+            Unknown = 0,
+            NotNull = 1,
+            Nullable = 2,
+        }
+
+#if NET6_0_OR_GREATER
+        private readonly NullabilityInfoContext _context = new NullabilityInfoContext();
+
+        public NullabilityState GetNullabilityState(ParameterInfo parameterInfo)
+        {
+            return (NullabilityState)_context.Create(parameterInfo).ReadState;
+        }
+#else
+        public NullabilityState GetNullabilityState(ParameterInfo parameterInfo)
+        {
+            foreach (var attr in parameterInfo.GetCustomAttributesData())
+            {
+                if (attr.AttributeType is { Namespace: "System.Runtime.CompilerServices", Name: "NullableAttribute" })
+                {
+                    return (NullabilityState)((byte)attr.ConstructorArguments[0].Value!);
+                }
+            }
+
+            return NullabilityState.Unknown;
+        }
+#endif
+    }
+}

--- a/src/Cocona.Core/Internal/ThrowHelper.cs
+++ b/src/Cocona.Core/Internal/ThrowHelper.cs
@@ -12,7 +12,10 @@ namespace Cocona.Internal
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(argument, paramName);
 #else
-            throw new ArgumentNullException(paramName);
+            if (argument is null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
 #endif
         }
     }

--- a/test/Cocona.Test/Cocona.Test.csproj
+++ b/test/Cocona.Test/Cocona.Test.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Cocona\StrongNameKey.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);1701;1702;CS1998</NoWarn>
     <nullable>annotations</nullable>
-    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
@@ -298,6 +298,16 @@ namespace Cocona.Test.Command.CommandProvider
         }
 
         [Fact]
+        public void Default_Arguments_Required_After_Optional()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_Required_After_Optional)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
+
+            }).Message.Should().Be("The required arguments must be placed before the optional arguments. (Argument: arg2)");
+        }
+
+        [Fact]
         public void Default_Arguments_HasDescription_NoReturn()
         {
             var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(GetMethod<CommandTest>(nameof(CommandTest.Default_Arguments_HasDescription_NoReturn)), false, new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(), default);
@@ -727,6 +737,7 @@ namespace Cocona.Test.Command.CommandProvider
             public void Default_Arguments_HasDescription_NoReturn([Argument(Description = "arg no.0")]int arg0) { }
             public void Default_Arguments_HasName_NoReturn([Argument("yet_another_arg0")]int arg0) { }
             public void Default_Arguments_Ordered_NoReturn([Argument(Order = 5)]int[] arg0, [Argument(Order = int.MinValue)]string[] arg1) { }
+            public void Default_Arguments_Required_After_Optional([Argument(Order = -10)]int? arg0, [Argument(Order = -20)]int arg1, [Argument(Order = 0)]int arg2) { } // arg1(Required), arg0(Optional), arg2(Required)
             public void Default_HasIgnoreParameter_NoReturn(string name, [Ignore]string ignored, [Argument]string arg0) { }
             public void Default_HasIgnoreValueTypeParameter_NoReturn(string name, [Ignore]int ignored, [Argument]string arg0) { }
             public void Default_TreatBooleanOptionAsDefaultFalse_NoReturn(bool flag0) { }

--- a/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
+++ b/test/Cocona.Test/Command/CommandProvider/CreateCommandTest.cs
@@ -511,6 +511,196 @@ namespace Cocona.Test.Command.CommandProvider
             cmd.Aliases.Should().BeEquivalentTo(new[] { "_alias1", "_alias2" });
         }
 
+        [Fact]
+        public void NullableAsOptional_Nullable_Enabled()
+        {
+#nullable enable
+            void TestMethod(
+                string option0NonNullable,
+                int option1NonNullable,
+                string? option2Nullable,
+                int? option3Nullable,
+                bool option4NonNullable,
+                bool? option5Nullable,
+
+                [Argument]
+                string arg0NonNullable,
+                [Argument]
+                int arg1NonNullable,
+                [Argument]
+                string? arg2Nullable,
+                [Argument]
+                int? arg3Nullable
+            )
+            { }
+#nullable restore
+            var metadata = new object[]
+            {
+                new CommandNameMetadata("TestMethod"),
+            };
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(
+                new Action<string, int, string?, int?, bool, bool?, string, int, string?, int?>(TestMethod).Method,
+                isSingleCommand: true,
+                new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(),
+                default,
+                metadata
+            );
+            cmd.Name.Should().Be("TestMethod");
+            cmd.Options.Should().HaveCount(6);
+            // [NotNull] string
+            cmd.Options[0].Name.Should().Be("option0NonNullable");
+            cmd.Options[0].IsRequired.Should().BeTrue();
+            cmd.Options[0].OptionType.Should().Be<string>();
+            cmd.Options[0].DefaultValue.HasValue.Should().BeFalse();
+            // [NotNull] int
+            cmd.Options[1].Name.Should().Be("option1NonNullable");
+            cmd.Options[1].IsRequired.Should().BeTrue();
+            cmd.Options[1].OptionType.Should().Be<int>();
+            cmd.Options[1].DefaultValue.HasValue.Should().BeFalse();
+            // [Nullable] string
+            cmd.Options[2].Name.Should().Be("option2Nullable");
+            cmd.Options[2].IsRequired.Should().BeFalse();
+            cmd.Options[2].OptionType.Should().Be<string>();
+            cmd.Options[2].DefaultValue.HasValue.Should().BeTrue();
+            cmd.Options[2].DefaultValue.Value.Should().Be(null);
+            // [Nullable] int?
+            cmd.Options[3].Name.Should().Be("option3Nullable");
+            cmd.Options[3].IsRequired.Should().BeFalse();
+            cmd.Options[3].OptionType.Should().Be<int?>();
+            cmd.Options[3].DefaultValue.HasValue.Should().BeTrue();
+            cmd.Options[3].DefaultValue.Value.Should().Be(null);
+            // [NotNull] bool
+            cmd.Options[4].Name.Should().Be("option4NonNullable");
+            cmd.Options[4].IsRequired.Should().BeFalse(); // non-nullable bool is optional by default.
+            cmd.Options[4].OptionType.Should().Be<bool>();
+            cmd.Options[4].DefaultValue.HasValue.Should().BeTrue();
+            cmd.Options[4].DefaultValue.Value.Should().Be(false);
+            // [Nullable] bool?
+            cmd.Options[5].Name.Should().Be("option5Nullable");
+            cmd.Options[5].IsRequired.Should().BeFalse();
+            cmd.Options[5].OptionType.Should().Be<bool?>();
+            cmd.Options[5].DefaultValue.HasValue.Should().BeTrue();
+            cmd.Options[5].DefaultValue.Value.Should().Be(null);
+
+            cmd.Arguments.Should().HaveCount(4);
+            // [NotNull] string
+            cmd.Arguments[0].Name.Should().Be("arg0NonNullable");
+            cmd.Arguments[0].IsRequired.Should().BeTrue();
+            cmd.Arguments[0].ArgumentType.Should().Be<string>();
+            cmd.Arguments[0].DefaultValue.HasValue.Should().BeFalse();
+            // [NotNull] int
+            cmd.Arguments[1].Name.Should().Be("arg1NonNullable");
+            cmd.Arguments[1].IsRequired.Should().BeTrue();
+            cmd.Arguments[1].ArgumentType.Should().Be<int>();
+            cmd.Arguments[1].DefaultValue.HasValue.Should().BeFalse();
+            // [Nullable] string?
+            cmd.Arguments[2].Name.Should().Be("arg2Nullable");
+            cmd.Arguments[2].IsRequired.Should().BeFalse();
+            cmd.Arguments[2].ArgumentType.Should().Be<string>();
+            cmd.Arguments[3].DefaultValue.HasValue.Should().BeTrue();
+            cmd.Arguments[3].DefaultValue.Value.Should().Be(null);
+            // [Nullable] int?
+            cmd.Arguments[3].Name.Should().Be("arg3Nullable");
+            cmd.Arguments[3].IsRequired.Should().BeFalse();
+            cmd.Arguments[3].ArgumentType.Should().Be<int?>();
+            cmd.Arguments[3].DefaultValue.HasValue.Should().BeTrue();
+            cmd.Arguments[3].DefaultValue.Value.Should().Be(null);
+        }
+
+        [Fact]
+        public void NullableAsOptional_Nullable_Disabled()
+        {
+#nullable disable
+#pragma warning disable CS8632
+            void TestMethod(
+                string option0NonNullable, // Unknown
+                int option1NonNullable, // NotNull
+                string? option2Nullable, // Nullable
+                int? option3Nullable, // Nullable
+                bool option4NonNullable, // NotNull
+                bool? option5Nullable, // Nullable
+
+                [Argument]
+                string arg0NonNullable, // Unknown
+                [Argument]
+                int arg1NonNullable, // NotNull
+                [Argument]
+                string? arg2Nullable, // Nullable
+                [Argument]
+                int? arg3Nullable // Nullable
+            )
+            { }
+#pragma warning restore CS8632
+#nullable restore
+            var metadata = new object[]
+            {
+                new CommandNameMetadata("TestMethod"),
+            };
+            var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(
+                new Action<string, int, string?, int?, bool, bool?, string, int, string?, int?>(TestMethod).Method,
+                isSingleCommand: true,
+                new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(),
+                default,
+                metadata
+            );
+            cmd.Name.Should().Be("TestMethod");
+            cmd.Options.Should().HaveCount(6);
+            cmd.Options[0].Name.Should().Be("option0NonNullable");
+            cmd.Options[0].IsRequired.Should().BeTrue(); // Unknown
+            cmd.Options[0].OptionType.Should().Be<string>();
+            cmd.Options[1].Name.Should().Be("option1NonNullable");
+            cmd.Options[1].IsRequired.Should().BeTrue(); // NotNull
+            cmd.Options[1].OptionType.Should().Be<int>();
+            cmd.Options[2].Name.Should().Be("option2Nullable");
+            cmd.Options[2].IsRequired.Should().BeFalse(); // Nullable
+            cmd.Options[2].OptionType.Should().Be<string>();
+            cmd.Options[3].Name.Should().Be("option3Nullable");
+            cmd.Options[3].IsRequired.Should().BeFalse(); // Nullable
+            cmd.Options[3].OptionType.Should().Be<int?>();
+            cmd.Options[4].Name.Should().Be("option4NonNullable");
+            cmd.Options[4].IsRequired.Should().BeFalse(); // non-nullable bool is optional by default.
+            cmd.Options[4].OptionType.Should().Be<bool>();
+            cmd.Options[5].Name.Should().Be("option5Nullable");
+            cmd.Options[5].IsRequired.Should().BeFalse(); // Nullable
+            cmd.Options[5].OptionType.Should().Be<bool?>();
+            cmd.Arguments.Should().HaveCount(4);
+            cmd.Arguments[0].Name.Should().Be("arg0NonNullable");
+            cmd.Arguments[0].IsRequired.Should().BeTrue(); // Unknown
+            cmd.Arguments[0].ArgumentType.Should().Be<string>();
+            cmd.Arguments[1].Name.Should().Be("arg1NonNullable");
+            cmd.Arguments[1].IsRequired.Should().BeTrue(); // NotNull
+            cmd.Arguments[1].ArgumentType.Should().Be<int>();
+            cmd.Arguments[2].Name.Should().Be("arg2Nullable");
+            cmd.Arguments[2].IsRequired.Should().BeFalse(); // Nullable
+            cmd.Arguments[2].ArgumentType.Should().Be<string>();
+            cmd.Arguments[3].Name.Should().Be("arg3Nullable");
+            cmd.Arguments[3].IsRequired.Should().BeFalse(); // Nullable
+            cmd.Arguments[3].ArgumentType.Should().Be<int?>();
+        }
+
+        [Fact]
+        public void NullableAsOptional_ParameterSet_CanNotBe_Nullable()
+        {
+#nullable enable
+            void TestMethod(ParameterSetTest_Parameterized? parameterSetTestParameterized)
+            { }
+#nullable restore
+            var metadata = new object[]
+            {
+                new CommandNameMetadata("TestMethod"),
+            };
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                var cmd = new CoconaCommandProvider(Array.Empty<Type>()).CreateCommand(
+                    new Action<ParameterSetTest_Parameterized?>(TestMethod).Method,
+                    isSingleCommand: true,
+                    new Dictionary<string, List<(MethodInfo Method, CommandOverloadAttribute Attribute)>>(),
+                    default,
+                    metadata
+                );
+            });
+        }
+
         private static MethodInfo GetMethod<T>(string methodName)
         {
             return typeof(T).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
@@ -573,5 +763,7 @@ namespace Cocona.Test.Command.CommandProvider
         {
             public int CommandMethodForwardedToTarget([Argument]string arg0) => 0;
         }
+
+        public record ParameterSetTest_Parameterized(int ValueA, string ValueB) : ICommandParameterSet;
     }
 }

--- a/test/Cocona.Test/CommandLine/CoconaCommandLineParserTest.cs
+++ b/test/Cocona.Test/CommandLine/CoconaCommandLineParserTest.cs
@@ -562,6 +562,126 @@ namespace Cocona.Test.CommandLine
         }
 
         [Fact]
+        public void ParseCommand_LongOptions_NullableBoolean_Equal_False_DefaultTrue()
+        {
+            var args = new[] { "--flag=false" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new CommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(bool?), "flag", new [] { 'f' }, "", new CoconaDefaultValue(null)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Options[0].Value.Should().Be("false");
+            parsed.Arguments.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseCommand_LongOptions_NullableBoolean_Equal_Non_True()
+        {
+            var args = new[] { "--flag=0" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new CommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(bool?), "flag", new [] { 'f' }, "", new CoconaDefaultValue(null)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Options[0].Value.Should().Be("false");
+            parsed.Arguments.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseCommand_LongOptions_NullableBoolean_Equal_True_DefaultTrue()
+        {
+            var args = new[] { "--flag=true" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new CommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(bool?), "flag", new [] { 'f' }, "", new CoconaDefaultValue(null)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Options[0].Value.Should().Be("true");
+            parsed.Arguments.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseCommand_LongOptions_NullableBoolean_Equal_False_DefaultFalse()
+        {
+            var args = new[] { "--flag=false" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new CommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(bool?), "flag", new [] { 'f' }, "", new CoconaDefaultValue(null)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Options[0].Value.Should().Be("false");
+            parsed.Arguments.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseCommand_LongOptions_NullableBoolean_Equal_True_DefaultFalse()
+        {
+            var args = new[] { "--flag=true" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new CommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(bool?), "flag", new [] { 'f' }, "", new CoconaDefaultValue(null)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Options[0].Value.Should().Be("true");
+            parsed.Arguments.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseCommand_LongOptions_NullableBoolean_NonEqual_Ignored()
+        {
+            var args = new[] { "--flag", "false" };
+            var parsed = new CoconaCommandLineParser().ParseCommand(
+                args,
+                new CommandOptionDescriptor[]
+                {
+                    CreateCommandOption(typeof(bool?), "flag", new [] { 'f' }, "", new CoconaDefaultValue(null)),
+                },
+                new CommandArgumentDescriptor[]
+                {
+                }
+            );
+            parsed.Should().NotBeNull();
+            parsed.Options.Should().HaveCount(1);
+            parsed.Options[0].Value.Should().Be("true"); // --flag
+            parsed.Arguments.Should().NotBeEmpty(); // false
+        }
+
+        [Fact]
         public void ParseCommand_ShortOptionWithValue_Arguments()
         {
             var args = new[] { "-rm", "Message", "src1", "src2", "src3", "dest" };

--- a/test/Cocona.Test/Integration/BuildAppCommandsWithBuilderTest.cs
+++ b/test/Cocona.Test/Integration/BuildAppCommandsWithBuilderTest.cs
@@ -236,5 +236,133 @@ namespace Cocona.Test.Integration
             stdOut.Should().NotContain("--hidden");
             exitCode.Should().Be(129);
         }
+
+        [Fact]
+        public void Parameter_NotNull_Or_Unknown_Required_RefType()
+        {
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((string name) => Console.WriteLine($"Hello {name}!")); // [NotNull]
+                    app.Run();
+                });
+
+                stdErr.Should().Contain("'--name' is required");
+                exitCode.Should().Be(1);
+            }
+#nullable disable
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((string name) => Console.WriteLine($"Hello {name}!")); // [Unknown]
+                    app.Run();
+                });
+
+                stdErr.Should().Contain("'--name' is required");
+                exitCode.Should().Be(1);
+            }
+#nullable restore
+        }
+
+        [Fact]
+        public void Parameter_Nullable_Optional_RefType()
+        {
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((string? name) => Console.WriteLine($"Hello {(name ?? "Guest")}!"));
+                    app.Run();
+                });
+
+                stdErr.Should().BeEmpty();
+                stdOut.Should().Be("Hello Guest!" + Environment.NewLine);
+                exitCode.Should().Be(0);
+            }
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { "--name", "Alice" }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((string? name) => Console.WriteLine($"Hello {(name ?? "Guest")}!"));
+                    app.Run();
+                });
+
+                stdErr.Should().BeEmpty();
+                stdOut.Should().Be("Hello Alice!" + Environment.NewLine);
+                exitCode.Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public void Parameter_Nullable_Optional_ValueType()
+        {
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((int? year) => Console.WriteLine($"Hello {(year ?? 2022)}!"));
+                    app.Run();
+                });
+
+                stdErr.Should().BeEmpty();
+                stdOut.Should().Be("Hello 2022!" + Environment.NewLine);
+                exitCode.Should().Be(0);
+            }
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { "--year", "2000" }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((int? year) => Console.WriteLine($"Hello {(year ?? 2022)}!"));
+                    app.Run();
+                });
+
+                stdErr.Should().BeEmpty();
+                stdOut.Should().Be("Hello 2000!" + Environment.NewLine);
+                exitCode.Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public void Parameter_Nullable_Optional_Boolean()
+        {
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((bool? flag) => Console.WriteLine($"Flag: {(flag.HasValue ? flag.Value : "(null)")}"));
+                    app.Run();
+                });
+
+                stdErr.Should().BeEmpty();
+                stdOut.Should().Be("Flag: (null)" + Environment.NewLine);
+                exitCode.Should().Be(0);
+            }
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { "--flag" }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((bool? flag) => Console.WriteLine($"Flag: {(flag.HasValue ? flag.Value : "(null)")}"));
+                    app.Run();
+                });
+
+                stdErr.Should().BeEmpty();
+                stdOut.Should().Be("Flag: True" + Environment.NewLine);
+                exitCode.Should().Be(0);
+            }
+            {
+                var (stdOut, stdErr, exitCode) = Run(new string[] { "--flag=false" }, args =>
+                {
+                    var app = CoconaApp.Create(args);
+                    app.AddCommand((bool? flag) => Console.WriteLine($"Flag: {(flag.HasValue ? flag.Value : "(null)")}"));
+                    app.Run();
+                });
+
+                stdErr.Should().BeEmpty();
+                stdOut.Should().Be("Flag: False" + Environment.NewLine);
+                exitCode.Should().Be(0);
+            }
+        }
     }
 }

--- a/test/Cocona.Test/Integration/EndToEndTestBase.cs
+++ b/test/Cocona.Test/Integration/EndToEndTestBase.cs
@@ -25,6 +25,13 @@ namespace Cocona.Test.Integration
     [Collection("End to End")] // NOTE: Test cases use `Console` and does not run in parallel.
     public abstract class EndToEndTestBase
     {
+#if !NET5_0_OR_GREATER
+        static EndToEndTestBase()
+        {
+            ModuleInitializers.EnforceCurrentCulture();
+        }
+#endif
+
         protected (string StandardOut, string StandardError, int ExitCode) Run(string[] args, Action<string[]> action)
         {
             var stdOutWriter = new StringWriter();

--- a/test/Cocona.Test/Internal/NullabilityInfoContextHelperTest.cs
+++ b/test/Cocona.Test/Internal/NullabilityInfoContextHelperTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cocona.Internal;
+using FluentAssertions;
+using Xunit;
+
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+
+namespace Cocona.Test.Internal
+{
+    public class NullabilityInfoContextHelperTest
+    {
+        [Fact]
+        public void ValueType_Nullable()
+        {
+            var helper = new NullabilityInfoContextHelper();
+            Action<int?> a = (int? value) => { };
+            helper.GetNullabilityState(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+        }
+
+        [Fact]
+        public void ValueType_NotNull()
+        {
+            var helper = new NullabilityInfoContextHelper();
+            Action<int> a = (int value) => { };
+            helper.GetNullabilityState(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.NotNull);
+        }
+
+        [Fact]
+        public void NullableReferenceType_Enable_Nullable()
+        {
+#nullable enable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string?> a = (string? value) => { };
+            helper.GetNullabilityState(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+#nullable restore
+        }
+
+        [Fact]
+        public void NullableReferenceType_Enable_NotNull()
+        {
+#nullable enable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string> a = (string value) => { };
+            helper.GetNullabilityState(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.NotNull);
+#nullable restore
+        }
+
+        [Fact]
+        public void NullableReferenceType_Disable_Nullable()
+        {
+#nullable disable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string?> a = (string? value) => { };
+            helper.GetNullabilityState(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+#nullable restore
+        }
+
+        [Fact]
+        public void NullableReferenceType_Disable_NotNull()
+        {
+#nullable disable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string> a = (string value) => { };
+            helper.GetNullabilityState(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Unknown);
+#nullable restore
+        }
+    }
+}

--- a/test/Cocona.Test/Internal/NullabilityInfoContextHelperTest.cs
+++ b/test/Cocona.Test/Internal/NullabilityInfoContextHelperTest.cs
@@ -68,5 +68,82 @@ namespace Cocona.Test.Internal
             helper.GetNullabilityState(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Unknown);
 #nullable restore
         }
+
+        [Fact]
+        public void Compat_ValueType_Nullable()
+        {
+            var helper = new NullabilityInfoContextHelper();
+            Action<int?> a = (int? value) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+        }
+
+        [Fact]
+        public void Compat_ValueType_NotNull()
+        {
+            var helper = new NullabilityInfoContextHelper();
+            Action<int> a = (int value) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.NotNull);
+        }
+
+
+        [Fact]
+        public void Compat_NullableReferenceType_Enable_Nullable()
+        {
+#nullable enable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string?> a = (string? value) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+#nullable restore
+        }
+
+        [Fact]
+        public void Compat_NullableReferenceType_Enable_Nullable_Array()
+        {
+#nullable enable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string[]?> a = (string[]? value) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+#nullable restore
+        }
+
+        [Fact]
+        public void Compat_NullableReferenceType_Enable_NotNull()
+        {
+#nullable enable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string> a = (string value) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.NotNull);
+#nullable restore
+        }
+
+        [Fact]
+        public void Compat_NullableReferenceType_Disable_Nullable_NullableContextAttribute()
+        {
+#nullable disable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string?> a = /*[NullableContext(0x2)]*/(string? value) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+#nullable restore
+        }
+
+        [Fact]
+        public void Compat_NullableReferenceType_Disable_Nullable_NullableAttribute()
+        {
+#nullable disable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string?, string> a = (/*[Nullable(0x2)]*/string? value, string valueB) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Nullable);
+#nullable restore
+        }
+
+        [Fact]
+        public void Compat_NullableReferenceType_Disable_NotNull()
+        {
+#nullable disable
+            var helper = new NullabilityInfoContextHelper();
+            Action<string> a = (string value) => { };
+            helper.GetNullabilityState_Compat(a.Method.GetParameters()[0]).Should().Be(NullabilityInfoContextHelper.NullabilityState.Unknown);
+#nullable restore
+        }
     }
 }

--- a/test/Cocona.Test/Shims/System.Runtime.CompilerServices.IsExternalInit.cs
+++ b/test/Cocona.Test/Shims/System.Runtime.CompilerServices.IsExternalInit.cs
@@ -1,0 +1,14 @@
+#if !NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    internal class IsExternalInit : Attribute
+    {
+    }
+}
+#endif

--- a/test/Cocona.Test/Shims/System.Runtime.CompilerServices.ModuleInitializerAttribute.cs
+++ b/test/Cocona.Test/Shims/System.Runtime.CompilerServices.ModuleInitializerAttribute.cs
@@ -1,0 +1,14 @@
+﻿#if !NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    internal class ModuleInitializerAttribute : Attribute
+    {
+    }
+}
+#endif


### PR DESCRIPTION
If a method parameter is nullable, it will be treated as optional.

```csharp
app.AddCommand("optional-param", (int? age, [Argument]string? name) =>
{
    Console.WriteLine($"Hello {(name ?? "Guest")} ({(age?.ToString() ?? "-")})!");
});
```