### PR TITLE
Disable support for shell completion by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ or
 
 Currently, The supported shells are `bash` and `zsh`.
 
-This feature is enabled by default, or you can set the `EnableShellCompletionSupport` option to `false` if you don't need it.
+This feature is **disabled** by default, or you can set the `EnableShellCompletionSupport` option to `true` if you need it.
 
 It is also possible to dynamically generate command-line completion candidates and to prepare candidates at script generation time. Please see the sample below for more details.
 

--- a/samples/GettingStarted.SubCommandApp/Program.cs
+++ b/samples/GettingStarted.SubCommandApp/Program.cs
@@ -8,7 +8,10 @@ namespace CoconaSample.GettingStarted.SubCommandApp
     {
         static void Main(string[] args)
         {
-            CoconaApp.Run<Program>(args);
+            CoconaApp.Run<Program>(args, options =>
+            {
+                options.EnableShellCompletionSupport = true;
+            });
         }
 
         [Command(Description = "Say hello")]

--- a/src/Cocona.Lite/CoconaLiteAppOptions.cs
+++ b/src/Cocona.Lite/CoconaLiteAppOptions.cs
@@ -34,8 +34,8 @@ namespace Cocona
         public bool EnableConvertArgumentNameToLowerCase { get; set; } = true;
 
         /// <summary>
-        /// Specify enable shell completion support. The default value is true.
+        /// Specify enable shell completion support. The default value is false.
         /// </summary>
-        public bool EnableShellCompletionSupport { get; set; } = true;
+        public bool EnableShellCompletionSupport { get; set; } = false;
     }
 }

--- a/src/Cocona/CoconaAppOptions.cs
+++ b/src/Cocona/CoconaAppOptions.cs
@@ -35,8 +35,8 @@ namespace Cocona
         public bool EnableConvertArgumentNameToLowerCase { get; set; } = true;
 
         /// <summary>
-        /// Specify enable shell completion support. The default value is true.
+        /// Specify enable shell completion support. The default value is false.
         /// </summary>
-        public bool EnableShellCompletionSupport { get; set; } = true;
+        public bool EnableShellCompletionSupport { get; set; } = false;
     }
 }

--- a/test/Cocona.Test/Integration/CoconaAppRunTest.cs
+++ b/test/Cocona.Test/Integration/CoconaAppRunTest.cs
@@ -61,9 +61,21 @@ namespace Cocona.Test.Integration
         [InlineData(RunBuilderMode.CreateHostBuilder)]
         [InlineData(RunBuilderMode.CreateBuilder)]
         [InlineData(RunBuilderMode.Shortcut)]
-        public void CoconaApp_Run_Single_Completion(RunBuilderMode mode)
+        public void CoconaApp_Run_Single_Completion_Disabled_By_Default(RunBuilderMode mode)
         {
             var (stdOut, stdErr, exitCode) = Run<TestCommand_Single>(mode, new string[] { "--completion", "zsh" });
+
+            stdErr.Should().Contain("Unknown option 'completion'");
+            exitCode.Should().Be(129);
+        }
+
+        [Theory]
+        [InlineData(RunBuilderMode.CreateHostBuilder)]
+        [InlineData(RunBuilderMode.CreateBuilder)]
+        [InlineData(RunBuilderMode.Shortcut)]
+        public void CoconaApp_Run_Single_Completion(RunBuilderMode mode)
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Single>(mode, new string[] { "--completion", "zsh" }, options => { options.EnableShellCompletionSupport = true; });
 
             stdOut.Should().Contain("#compdef");
             stdErr.Should().BeEmpty();
@@ -76,7 +88,7 @@ namespace Cocona.Test.Integration
         [InlineData(RunBuilderMode.Shortcut)]
         public void CoconaApp_Run_Single_CompletionCandidates(RunBuilderMode mode)
         {
-            var (stdOut, stdErr, exitCode) = Run<TestCommand_Single_Candidates>(mode, new string[] { "--completion-candidates", "bash:name", "--", "A" });
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Single_Candidates>(mode, new string[] { "--completion-candidates", "bash:name", "--", "A" }, options => { options.EnableShellCompletionSupport = true; });
 
             stdOut.Should().Contain("Alice");
             stdErr.Should().BeEmpty();
@@ -381,9 +393,21 @@ namespace Cocona.Test.Integration
         [InlineData(RunBuilderMode.CreateHostBuilder)]
         [InlineData(RunBuilderMode.CreateBuilder)]
         [InlineData(RunBuilderMode.Shortcut)]
-        public void CoconaApp_Run_Multiple_Completion(RunBuilderMode mode)
+        public void CoconaApp_Run_Multiple_Completion_Disabled_By_Default(RunBuilderMode mode)
         {
             var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple>(mode, new string[] { "--completion", "zsh" });
+
+            stdErr.Should().Contain("Unknown option 'completion'");
+            exitCode.Should().Be(129);
+        }
+
+        [Theory]
+        [InlineData(RunBuilderMode.CreateHostBuilder)]
+        [InlineData(RunBuilderMode.CreateBuilder)]
+        [InlineData(RunBuilderMode.Shortcut)]
+        public void CoconaApp_Run_Multiple_Completion(RunBuilderMode mode)
+        {
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple>(mode, new string[] { "--completion", "zsh" }, options => { options.EnableShellCompletionSupport = true; });
 
             stdOut.Should().Contain("#compdef");
             stdErr.Should().BeEmpty();
@@ -396,7 +420,7 @@ namespace Cocona.Test.Integration
         [InlineData(RunBuilderMode.Shortcut)]
         public void CoconaApp_Run_Multiple_CompletionCandidates(RunBuilderMode mode)
         {
-            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple_Candidates>(mode, new string[] { "--completion-candidates", "bash:name", "--", "hello", "A" });
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple_Candidates>(mode, new string[] { "--completion-candidates", "bash:name", "--", "hello", "A" }, options => { options.EnableShellCompletionSupport = true; });
 
             stdOut.Should().Contain("Karen");
             stdErr.Should().BeEmpty();
@@ -409,7 +433,7 @@ namespace Cocona.Test.Integration
         [InlineData(RunBuilderMode.Shortcut)]
         public void CoconaApp_Run_Multiple_CompletionCandidates_UnknownCommand(RunBuilderMode mode)
         {
-            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple_Candidates>(mode, new string[] { "--completion-candidates", "bash:name", "--", "unknown-command", "A" });
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple_Candidates>(mode, new string[] { "--completion-candidates", "bash:name", "--", "unknown-command", "A" }, options => { options.EnableShellCompletionSupport = true; });
 
             stdOut.Should().BeEmpty();
             stdErr.Should().NotBeEmpty();
@@ -422,7 +446,7 @@ namespace Cocona.Test.Integration
         [InlineData(RunBuilderMode.Shortcut)]
         public void CoconaApp_Run_Multiple_CompletionCandidates_UnknownOption(RunBuilderMode mode)
         {
-            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple_Candidates>(mode, new string[] { "--completion-candidates", "bash:unknown-option", "--", "hello", "A" });
+            var (stdOut, stdErr, exitCode) = Run<TestCommand_Multiple_Candidates>(mode, new string[] { "--completion-candidates", "bash:unknown-option", "--", "hello", "A" }, options => { options.EnableShellCompletionSupport = true; });
 
             stdOut.Should().BeEmpty();
             stdErr.Should().BeEmpty();


### PR DESCRIPTION
## Breaking change
Support for Shell completion feature is now disabled by default.
If you want to continue to enable it, set the `EnableShellCompletionSupport` option to `true`.
