### PR TITLE
Throw exceptions in Run when building the application

### DIFF
--- a/src/Cocona.Core/Command/CoconaBootstrapper.cs
+++ b/src/Cocona.Core/Command/CoconaBootstrapper.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cocona.Application;
+using Cocona.Command.Dispatcher;
+using Cocona.CommandLine;
+using Cocona.Internal;
+using Cocona.Resources;
+
+namespace Cocona.Command;
+
+public class CoconaBootstrapper : ICoconaBootstrapper
+{
+    private readonly ICoconaCommandLineArgumentProvider _commandLineArgumentProvider;
+    private readonly ICoconaCommandProvider _commandProvider;
+    private readonly ICoconaCommandResolver _commandResolver;
+    private readonly ICoconaCommandDispatcher _dispatcher;
+    private readonly ICoconaConsoleProvider _console;
+
+    private CommandCollection? _commandCollection;
+    public CoconaBootstrapper(
+        ICoconaCommandLineArgumentProvider commandLineArgumentProvider,
+        ICoconaCommandProvider commandProvider,
+        ICoconaCommandResolver commandResolver,
+        ICoconaCommandDispatcher dispatcher,
+        ICoconaConsoleProvider console
+    )
+    {
+        _commandLineArgumentProvider = commandLineArgumentProvider;
+        _commandProvider = commandProvider;
+        _commandResolver = commandResolver;
+        _dispatcher = dispatcher;
+        _console = console;
+    }
+
+    public void Initialize()
+    {
+        _commandCollection = _commandProvider.GetCommandCollection();
+    }
+
+    public async ValueTask<int> RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var resolved = _commandResolver.ParseAndResolve(_commandCollection ?? throw new CoconaException("Call Initialize before RunAsync"), _commandLineArgumentProvider.GetArguments());
+            return await _dispatcher.DispatchAsync(resolved, cancellationToken);
+        }
+        catch (CommandNotFoundException cmdNotFoundEx)
+        {
+            if (string.IsNullOrWhiteSpace(cmdNotFoundEx.Command))
+            {
+                _console.Error.WriteLine(string.Format(Strings.Dispatcher_Error_CommandNotFound, cmdNotFoundEx.Message));
+            }
+            else
+            {
+                _console.Error.WriteLine(string.Format(Strings.Dispatcher_Error_NotACommand, cmdNotFoundEx.Command));
+            }
+
+            var similarCommands = cmdNotFoundEx.ImplementedCommands.All.Where(x => Levenshtein.GetDistance(cmdNotFoundEx.Command.ToLowerInvariant(), x.Name.ToLowerInvariant()) < 3).ToArray();
+            if (similarCommands.Any())
+            {
+                _console.Error.WriteLine();
+                _console.Error.WriteLine(Strings.Dispatcher_Error_SimilarCommands);
+                foreach (var c in similarCommands)
+                {
+                    _console.Error.WriteLine($"  {c.Name}");
+                }
+            }
+
+            return 1;
+        }
+    }
+}

--- a/src/Cocona.Core/Command/CoconaCommandResolver.cs
+++ b/src/Cocona.Core/Command/CoconaCommandResolver.cs
@@ -8,24 +8,20 @@ namespace Cocona.Command
 {
     public class CoconaCommandResolver : ICoconaCommandResolver
     {
-        private readonly ICoconaCommandProvider _commandProvider;
         private readonly ICoconaCommandLineParser _commandLineParser;
         private readonly ICoconaCommandMatcher _commandMatcher;
 
         public CoconaCommandResolver(
-            ICoconaCommandProvider commandProvider,
             ICoconaCommandLineParser commandLineParser,
             ICoconaCommandMatcher commandMatcher
         )
         {
-            _commandProvider = commandProvider;
             _commandLineParser = commandLineParser;
             _commandMatcher = commandMatcher;
         }
 
-        public CommandResolverResult ParseAndResolve(IReadOnlyList<string> args)
+        public CommandResolverResult ParseAndResolve(CommandCollection commandCollection, IReadOnlyList<string> args)
         {
-            var commandCollection = _commandProvider.GetCommandCollection();
             var subCommandStack = new List<CommandDescriptor>();
 
             Retry:

--- a/src/Cocona.Core/Command/Dispatcher/ICoconaCommandDispatcher.cs
+++ b/src/Cocona.Core/Command/Dispatcher/ICoconaCommandDispatcher.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Cocona.Command.Dispatcher
 {
     public interface ICoconaCommandDispatcher
     {
-        ValueTask<int> DispatchAsync(CancellationToken cancellationToken = default);
+        ValueTask<int> DispatchAsync(CommandResolverResult commandResolverResult, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Cocona.Core/Command/Dispatcher/Middlewares/HandleExceptionAndExitMiddleware.cs
+++ b/src/Cocona.Core/Command/Dispatcher/Middlewares/HandleExceptionAndExitMiddleware.cs
@@ -1,11 +1,13 @@
-﻿using Cocona.Application;
+using Cocona.Application;
 using Cocona.Command.Binder;
 using Cocona.Help;
+using Cocona.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Cocona.Resources;
 
 namespace Cocona.Command.Dispatcher.Middlewares
 {
@@ -39,6 +41,13 @@ namespace Cocona.Command.Dispatcher.Middlewares
                     }
                 }
                 return exitEx.ExitCode;
+            }
+            catch (Exception ex)
+            {
+                _console.Error.WriteLine($"Unhandled Exception: {ex.GetType().FullName}: {ex.Message}");
+                _console.Error.WriteLine(ex.StackTrace);
+
+                return 1;
             }
         }
     }

--- a/src/Cocona.Core/Command/ICoconaBootstrapper.cs
+++ b/src/Cocona.Core/Command/ICoconaBootstrapper.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cocona.Command
+{
+    public interface ICoconaBootstrapper
+    {
+        void Initialize();
+        ValueTask<int> RunAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Cocona.Core/Command/ICoconaCommandResolver.cs
+++ b/src/Cocona.Core/Command/ICoconaCommandResolver.cs
@@ -4,6 +4,6 @@ namespace Cocona.Command
 {
     public interface ICoconaCommandResolver
     {
-        CommandResolverResult ParseAndResolve(IReadOnlyList<string> args);
+        CommandResolverResult ParseAndResolve(CommandCollection commandCollection, IReadOnlyList<string> args);
     }
 }

--- a/src/Cocona.Core/Resources/Strings.Designer.cs
+++ b/src/Cocona.Core/Resources/Strings.Designer.cs
@@ -160,6 +160,33 @@ namespace Cocona.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Dispatcher_Error_CommandNotFound {
+            get {
+                return ResourceManager.GetString("Dispatcher_Error_CommandNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Dispatcher_Error_NotACommand {
+            get {
+                return ResourceManager.GetString("Dispatcher_Error_NotACommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Dispatcher_Error_SimilarCommands {
+            get {
+                return ResourceManager.GetString("Dispatcher_Error_SimilarCommands", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The command has exited with code &apos;{0}&apos;.{1}.
         /// </summary>
         internal static string Exception_TheCommandHasExitedWithCode {

--- a/src/Cocona.Core/Resources/Strings.ja-jp.resx
+++ b/src/Cocona.Core/Resources/Strings.ja-jp.resx
@@ -74,4 +74,13 @@
     <data name="OptionLikeCommand_MethodNotFound" xml:space="preserve">
         <value>オプション風コマンド '{0}' のメソッドが '{1}' に見つかりませんでした。</value>
     </data>
+    <data name="Dispatcher_Error_CommandNotFound" xml:space="preserve">
+        <value>エラー: {0}</value>
+    </data>
+    <data name="Dispatcher_Error_NotACommand" xml:space="preserve">
+        <value>エラー: '{0}' はコマンドではありません。 '--help' で使用方法を確認できます。</value>
+    </data>
+    <data name="Dispatcher_Error_SimilarCommands" xml:space="preserve">
+        <value>類似するコマンド:</value>
+    </data>
 </root>

--- a/src/Cocona.Core/Resources/Strings.resx
+++ b/src/Cocona.Core/Resources/Strings.resx
@@ -180,4 +180,13 @@
   <data name="Help_Description_AllowedValues" xml:space="preserve">
       <value>Allowed values</value>
   </data>
+  <data name="Dispatcher_Error_CommandNotFound" xml:space="preserve">
+      <value>Error: {0}</value>
+  </data>
+  <data name="Dispatcher_Error_NotACommand" xml:space="preserve">
+      <value>Error: '{0}' is not a command. See '--help' for usage.</value>
+  </data>
+  <data name="Dispatcher_Error_SimilarCommands" xml:space="preserve">
+      <value>Similar commands:</value>
+  </data>
 </root>

--- a/src/Cocona.Core/ShellCompletion/Candidate/CoconaCompletionCandidates.cs
+++ b/src/Cocona.Core/ShellCompletion/Candidate/CoconaCompletionCandidates.cs
@@ -11,21 +11,24 @@ namespace Cocona.ShellCompletion.Candidate
         private readonly ICoconaCompletionCandidatesMetadataFactory _completionCandidatesMetadataFactory;
         private readonly ICoconaCompletionCandidatesProviderFactory _completionCandidatesProviderFactory;
         private readonly ICoconaCommandResolver _commandResolver;
+        private readonly ICoconaCommandProvider _commandProvider;
 
         public CoconaCompletionCandidates(
             ICoconaCompletionCandidatesMetadataFactory completionCandidatesMetadataFactory,
             ICoconaCompletionCandidatesProviderFactory completionCandidatesProviderFactory,
-            ICoconaCommandResolver commandResolver
+            ICoconaCommandResolver commandResolver,
+            ICoconaCommandProvider commandProvider
         )
         {
             _completionCandidatesMetadataFactory = completionCandidatesMetadataFactory;
             _completionCandidatesProviderFactory = completionCandidatesProviderFactory;
             _commandResolver = commandResolver;
+            _commandProvider = commandProvider;
         }
 
         public IReadOnlyList<CompletionCandidateValue> GetOnTheFlyCandidates(string paramName, IReadOnlyList<string> args, int curPos, string? candidateHint)
         {
-            var result = _commandResolver.ParseAndResolve(args);
+            var result = _commandResolver.ParseAndResolve(_commandProvider.GetCommandCollection(), args);
 
             if (result.Success)
             {

--- a/src/Cocona.Lite/CoconaLiteAppOptions.cs
+++ b/src/Cocona.Lite/CoconaLiteAppOptions.cs
@@ -9,11 +9,6 @@ namespace Cocona
     public class CoconaLiteAppOptions
     {
         /// <summary>
-        /// Sets or gets whether Cocona or a command throws an exception, handle it and exit normally. The default value is true.
-        /// </summary>
-        public bool HandleExceptionAtRuntime { get; set; } = true;
-
-        /// <summary>
         /// If the type has public methods, Cocona treats as a command. The default value is true.
         /// </summary>
         public bool TreatPublicMethodsAsCommands { get; set; } = true;

--- a/src/Cocona.Lite/Lite/Resources/Strings.Designer.cs
+++ b/src/Cocona.Lite/Lite/Resources/Strings.Designer.cs
@@ -59,32 +59,5 @@ namespace Cocona.Lite.Resources {
                 resourceCulture = value;
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error: {0}.
-        /// </summary>
-        internal static string Host_Error_CommandNotFound {
-            get {
-                return ResourceManager.GetString("Host_Error_CommandNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error: &apos;{0}&apos; is not a command. See &apos;--help&apos; for usage..
-        /// </summary>
-        internal static string Host_Error_NotACommand {
-            get {
-                return ResourceManager.GetString("Host_Error_NotACommand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to .
-        /// </summary>
-        internal static string Host_Error_SimilarCommands {
-            get {
-                return ResourceManager.GetString("Host_Error_SimilarCommands", resourceCulture);
-            }
-        }
     }
 }

--- a/src/Cocona.Lite/Lite/Resources/Strings.ja-jp.resx
+++ b/src/Cocona.Lite/Lite/Resources/Strings.ja-jp.resx
@@ -11,13 +11,4 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="Host_Error_CommandNotFound" xml:space="preserve">
-        <value>エラー: {0}</value>
-    </data>
-    <data name="Host_Error_NotACommand" xml:space="preserve">
-        <value>エラー: '{0}' はコマンドではありません。 '--help' で使用方法を確認できます。</value>
-    </data>
-    <data name="Host_Error_SimilarCommands" xml:space="preserve">
-        <value>類似するコマンド:</value>
-    </data>
 </root>

--- a/src/Cocona.Lite/Lite/Resources/Strings.resx
+++ b/src/Cocona.Lite/Lite/Resources/Strings.resx
@@ -98,13 +98,4 @@
 	<resheader name="writer">
 		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
 	</resheader>
-    <data name="Host_Error_CommandNotFound" xml:space="preserve">
-        <value>Error: {0}</value>
-    </data>
-    <data name="Host_Error_NotACommand" xml:space="preserve">
-        <value>Error: '{0}' is not a command. See '--help' for usage.</value>
-    </data>
-    <data name="Host_Error_SimilarCommands" xml:space="preserve">
-        <value>Similar commands:</value>
-    </data>
 </root>

--- a/src/Cocona/CoconaAppOptions.cs
+++ b/src/Cocona/CoconaAppOptions.cs
@@ -10,11 +10,6 @@ namespace Cocona
     public class CoconaAppOptions
     {
         /// <summary>
-        /// Sets or gets whether Cocona or a command throws an exception, handle it and exit normally. The default value is true.
-        /// </summary>
-        public bool HandleExceptionAtRuntime { get; set; } = true;
-
-        /// <summary>
         /// If the type has public methods, Cocona treats as a command. The default value is true.
         /// </summary>
         public bool TreatPublicMethodsAsCommands { get; set; } = true;

--- a/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
+++ b/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Extensions.Hosting
             services.TryAddSingleton<ICoconaApplicationMetadataProvider, CoconaApplicationMetadataProvider>();
             services.TryAddSingleton<ICoconaConsoleProvider, CoconaConsoleProvider>();
             services.TryAddSingleton<ICoconaParameterValidatorProvider, DataAnnotationsParameterValidatorProvider>();
+            services.TryAddSingleton<ICoconaBootstrapper, CoconaBootstrapper>();
 
             services.TryAddTransient<ICoconaParameterBinder, CoconaParameterBinder>();
             services.TryAddTransient<ICoconaValueConverter, CoconaValueConverter>();

--- a/src/Cocona/Resources/Strings.Designer.cs
+++ b/src/Cocona/Resources/Strings.Designer.cs
@@ -59,32 +59,5 @@ namespace Cocona.Resources {
                 resourceCulture = value;
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error: {0}.
-        /// </summary>
-        internal static string Host_Error_CommandNotFound {
-            get {
-                return ResourceManager.GetString("Host_Error_CommandNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error: &apos;{0}&apos; is not a command. See &apos;--help&apos; for usage..
-        /// </summary>
-        internal static string Host_Error_NotACommand {
-            get {
-                return ResourceManager.GetString("Host_Error_NotACommand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Similar commands:.
-        /// </summary>
-        internal static string Host_Error_SimilarCommands {
-            get {
-                return ResourceManager.GetString("Host_Error_SimilarCommands", resourceCulture);
-            }
-        }
     }
 }

--- a/src/Cocona/Resources/Strings.ja-jp.resx
+++ b/src/Cocona/Resources/Strings.ja-jp.resx
@@ -11,13 +11,4 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="Host_Error_CommandNotFound" xml:space="preserve">
-        <value>エラー: {0}</value>
-    </data>
-    <data name="Host_Error_NotACommand" xml:space="preserve">
-        <value>エラー: '{0}' はコマンドではありません。 '--help' で使用方法を確認できます。</value>
-    </data>
-    <data name="Host_Error_SimilarCommands" xml:space="preserve">
-        <value>類似するコマンド:</value>
-    </data>
 </root>

--- a/src/Cocona/Resources/Strings.resx
+++ b/src/Cocona/Resources/Strings.resx
@@ -98,13 +98,4 @@
 	<resheader name="writer">
 		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
 	</resheader>
-    <data name="Host_Error_CommandNotFound" xml:space="preserve">
-        <value>Error: {0}</value>
-    </data>
-    <data name="Host_Error_NotACommand" xml:space="preserve">
-        <value>Error: '{0}' is not a command. See '--help' for usage.</value>
-    </data>
-    <data name="Host_Error_SimilarCommands" xml:space="preserve">
-        <value>Similar commands:</value>
-    </data>
 </root>

--- a/test/Cocona.Test/Command/CoconaConsoleAppBaseTest.cs
+++ b/test/Cocona.Test/Command/CoconaConsoleAppBaseTest.cs
@@ -52,7 +52,11 @@ namespace Cocona.Test.Command
             var serviceProvider = services.BuildServiceProvider();
 
             var commandInstance = serviceProvider.GetService<ConsoleAppTest>();
-            var result = await serviceProvider.GetService<ICoconaCommandDispatcher>().DispatchAsync();
+            var resolvedCommand = serviceProvider.GetRequiredService<ICoconaCommandResolver>().ParseAndResolve(
+                serviceProvider.GetRequiredService<ICoconaCommandProvider>().GetCommandCollection(),
+                serviceProvider.GetRequiredService<ICoconaCommandLineArgumentProvider>().GetArguments()
+            );
+            var result = await serviceProvider.GetService<ICoconaCommandDispatcher>().DispatchAsync(resolvedCommand);
             result.Should().Be(0);
             commandInstance.HasContext.Should().BeTrue();
         }

--- a/test/Cocona.Test/Command/CommandResolver/CoconaCommandResolverTest.cs
+++ b/test/Cocona.Test/Command/CommandResolver/CoconaCommandResolverTest.cs
@@ -19,12 +19,11 @@ namespace Cocona.Test.Command.CommandResolver
         {
             var commandCollection = new CommandCollection(new CommandDescriptor[] { });
             var resolver = new CoconaCommandResolver(
-                 new TestCommandProvider(commandCollection),
                  new CoconaCommandLineParser(),
                  new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { });
             resolve.Success.Should().BeFalse();
         }
 
@@ -36,12 +35,11 @@ namespace Cocona.Test.Command.CommandResolver
                 CreateCommand("Primary", new ICommandParameterDescriptor[]{}, true),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { });
             resolve.Success.Should().BeTrue();
             resolve.MatchedCommand.Name.Should().Be("Primary");
         }
@@ -54,12 +52,11 @@ namespace Cocona.Test.Command.CommandResolver
                 CreateCommand("Single", new ICommandParameterDescriptor[]{}, false),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            Assert.Throws<CommandNotFoundException>(() => resolver.ParseAndResolve(new string[] { }));
+            Assert.Throws<CommandNotFoundException>(() => resolver.ParseAndResolve(commandCollection, new string[] { }));
         }
 
         [Fact]
@@ -72,12 +69,11 @@ namespace Cocona.Test.Command.CommandResolver
                 CreateCommand("Bar", new ICommandParameterDescriptor[]{}, false),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { "Foo" });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { "Foo" });
             resolve.Success.Should().BeTrue();
             resolve.MatchedCommand.Name.Should().Be("Foo");
         }
@@ -104,12 +100,11 @@ namespace Cocona.Test.Command.CommandResolver
                 CreateCommand("Bar", new ICommandParameterDescriptor[]{}, false),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { "Foo", "--opt1", "123" });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { "Foo", "--opt1", "123" });
             resolve.Success.Should().BeTrue();
             resolve.MatchedCommand.Name.Should().Be("Foo");
             resolve.ParsedCommandLine.Options.Should().HaveCount(1);
@@ -131,12 +126,11 @@ namespace Cocona.Test.Command.CommandResolver
                     true),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { "--optlikecmd1", "Foo", "--opt1", "123", "--help", "--version" });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { "--optlikecmd1", "Foo", "--opt1", "123", "--help", "--version" });
             resolve.Success.Should().BeTrue();
             resolve.CommandCollection.Should().Be(commandCollection);
             resolve.MatchedCommand.Name.Should().Be("OptLikeCmd1");
@@ -178,12 +172,11 @@ namespace Cocona.Test.Command.CommandResolver
                 CreateCommand("Bar", new ICommandParameterDescriptor[]{}, false),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { "--optlikecmd1", "Foo", "--opt1", "123", "--help", "--version" });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { "--optlikecmd1", "Foo", "--opt1", "123", "--help", "--version" });
             resolve.Success.Should().BeTrue();
             resolve.CommandCollection.Should().Be(commandCollection);
             resolve.MatchedCommand.Name.Should().Be("OptLikeCmd1");
@@ -221,12 +214,11 @@ namespace Cocona.Test.Command.CommandResolver
                 CreateCommand("Bar", new ICommandParameterDescriptor[]{}, false),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { "Foo", "--opt1", "123", "--optlikecmd1", "--version" });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { "Foo", "--opt1", "123", "--optlikecmd1", "--version" });
             resolve.Success.Should().BeTrue();
             resolve.CommandCollection.Should().Be(commandCollection);
             resolve.MatchedCommand.Name.Should().Be("OptLikeCmd1");
@@ -261,12 +253,11 @@ namespace Cocona.Test.Command.CommandResolver
                     CommandFlags.None),
             });
             var resolver = new CoconaCommandResolver(
-                new TestCommandProvider(commandCollection),
                 new CoconaCommandLineParser(),
                 new CoconaCommandMatcher()
             );
 
-            var resolve = resolver.ParseAndResolve(new string[] { "Level1", "Level2", "--opt1", "123", "--optlikecmd1", "--version" });
+            var resolve = resolver.ParseAndResolve(commandCollection, new string[] { "Level1", "Level2", "--opt1", "123", "--optlikecmd1", "--version" });
             resolve.Success.Should().BeTrue();
             resolve.CommandCollection.Should().Be(commandCollectionNested);
             resolve.MatchedCommand.Name.Should().Be("OptLikeCmd1");

--- a/test/Cocona.Test/Integration/BuildAppCommandsWithBuilderTest.cs
+++ b/test/Cocona.Test/Integration/BuildAppCommandsWithBuilderTest.cs
@@ -32,17 +32,17 @@ namespace Cocona.Test.Integration
         [Fact]
         public void Unnamed_SingleCommand_Duplicated()
         {
-            var (stdOut, stdErr, exitCode) = Run(new string[] { }, args =>
+            Assert.Throws<CoconaException>(() =>
             {
-                var builder = CoconaApp.CreateBuilder(args);
-                var app = builder.Build();
-                app.AddCommand(() => Console.WriteLine("Hello Konnichiwa!"));
-                app.AddCommand(() => Console.WriteLine("Hello Konnichiwa!"));
-                app.Run();
-            });
-
-            stdErr.Should().Contain("The commands contains more then one primary command");
-            exitCode.Should().Be(1);
+                var (stdOut, stdErr, exitCode) = Run(new string[] { }, args =>
+                {
+                    var builder = CoconaApp.CreateBuilder(args);
+                    var app = builder.Build();
+                    app.AddCommand(() => Console.WriteLine("Hello Konnichiwa!"));
+                    app.AddCommand(() => Console.WriteLine("Hello Konnichiwa!"));
+                    app.Run();
+                });
+            }).Message.Should().Contain("The commands contains more then one primary command");
         }
 
         [Fact]

--- a/test/Cocona.Test/Integration/CoconaAppRunTest.cs
+++ b/test/Cocona.Test/Integration/CoconaAppRunTest.cs
@@ -745,21 +745,6 @@ namespace Cocona.Test.Integration
             stdErr.Should().Contain("ThrowCore()");
         }
 
-        [Theory]
-        [InlineData(RunBuilderMode.CreateHostBuilder)]
-        [InlineData(RunBuilderMode.CreateBuilder)]
-        [InlineData(RunBuilderMode.Shortcut)]
-        public void CoconaApp_Run_Throw_DisableHandling(RunBuilderMode mode)
-        {
-            Assert.Throws<AggregateException>(() =>
-            {
-                var (stdOut, stdErr, exitCode) = Run<TestCommand_Throw>(mode, new string[] { "my-help" }, options =>
-                {
-                    options.HandleExceptionAtRuntime = false;
-                });
-            }).Message.Should().Contain("Exception!");
-        }
-
         class TestCommand_Throw
         {
             public void Throw()
@@ -771,6 +756,26 @@ namespace Cocona.Test.Integration
             {
                 throw new Exception("Exception!");
             }
+        }
+
+        [Theory]
+        [InlineData(RunBuilderMode.CreateHostBuilder)]
+        [InlineData(RunBuilderMode.CreateBuilder)]
+        [InlineData(RunBuilderMode.Shortcut)]
+        public void CoconaApp_Run_ThrowOnBuild(RunBuilderMode mode)
+        {
+            Assert.Throws<CoconaException>(() =>
+            {
+                var (stdOut, stdErr, exitCode) = Run<TestCommand_ThrowOnBuild>(mode, new string[] { });
+            });
+        }
+
+        class TestCommand_ThrowOnBuild
+        {
+            [Command("duplicated")]
+            public void Throw() { }
+            [Command("duplicated")]
+            public void Throw2() { }
         }
 
         [Theory]


### PR DESCRIPTION
Throw exceptions in Run when building the application.
This change will make duplicate command errors and other errors become startup errors and not handled as runtime errors.