### PR TITLE
Wait for a timeout before shutting down when canceling with Ctrl+C

### DIFF
--- a/src/Cocona.Lite/CoconaLiteAppOptions.cs
+++ b/src/Cocona.Lite/CoconaLiteAppOptions.cs
@@ -32,5 +32,10 @@ namespace Cocona
         /// Specify enable shell completion support. The default value is false.
         /// </summary>
         public bool EnableShellCompletionSupport { get; set; } = false;
+
+        /// <summary>
+        /// Specify the timeout before the application is shutdown when Ctrl+C is pressed.
+        /// </summary>
+        public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(5);
     }
 }

--- a/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
+++ b/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
@@ -100,7 +100,7 @@ namespace Cocona.Lite.Hosting
                 .UseMiddleware((next, sp) => new InitializeCoconaLiteConsoleAppMiddleware(next, sp.GetRequiredService<ICoconaAppContextAccessor>()))
                 .UseMiddleware<CoconaCommandInvokeMiddleware>();
 
-            return new CoconaLiteAppHost(serviceProvider);
+            return new CoconaLiteAppHost(serviceProvider, options);
         }
 
         private static string[] GetCommandLineArguments()


### PR DESCRIPTION
### Applied to Cocona
```csharp
var builder = CoconaApp.CreateBuilder();
builder.Services.Configure<HostOptions>(options =>
{
     options.ShutdownTimeout = TimeSpan.FromSeconds(15);
});
```
### Applied to Cocona.Lite
```csharp
CoconaLiteApp.Create(options =>
{
    options.ShutdownTimeout = TimeSpan.FromSecond(15);
});
```