### PR TITLE
Move Obtaining Command Line Args Into DI

### DIFF
--- a/src/Cocona.Core/CommandLine/CoconaDefaultEnvironmentProvider.cs
+++ b/src/Cocona.Core/CommandLine/CoconaDefaultEnvironmentProvider.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Linq;
+
+namespace Cocona.CommandLine
+{
+    public class DefaultCoconaEnvironmentProvider : ICoconaEnvironmentProvider
+    {
+        public string[] GetCommandLineArgs() => Environment.GetCommandLineArgs() switch
+        {
+            { Length: > 0 } args => args.Skip(1).ToArray(),
+            _ => Array.Empty<string>(),
+        };
+
+    }
+}

--- a/src/Cocona.Core/CommandLine/ICoconaEnvonmentProvider.cs
+++ b/src/Cocona.Core/CommandLine/ICoconaEnvonmentProvider.cs
@@ -1,0 +1,10 @@
+namespace Cocona.CommandLine
+{
+    /// <summary>
+    /// A provider that abstracts calls to static System.Environment
+    /// </summary>
+    public interface ICoconaEnvironmentProvider
+    {
+        string[] GetCommandLineArgs();
+    }
+}

--- a/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
+++ b/src/Cocona.Lite/Lite/Hosting/CoconaLiteAppHostBuilder.cs
@@ -75,7 +75,7 @@ namespace Cocona.Lite.Hosting
             _configureOptions?.Invoke(options);
             services.AddSingleton(options);
 
-            services.AddCoconaCore(_args ?? GetCommandLineArguments());
+            services.AddCoconaCore(_args);
             services.AddCoconaShellCompletion();
 
             services.AddSingleton<CoconaLiteAppHostOptions>(new CoconaLiteAppHostOptions()
@@ -101,14 +101,6 @@ namespace Cocona.Lite.Hosting
                 .UseMiddleware<CoconaCommandInvokeMiddleware>();
 
             return new CoconaLiteAppHost(serviceProvider, options);
-        }
-
-        private static string[] GetCommandLineArguments()
-        {
-            var args = Environment.GetCommandLineArgs();
-            return args.Any()
-                ? args.Skip(1).ToArray() // args[0] is the path to executable binary.
-                : Array.Empty<string>();
         }
     }
 }

--- a/src/Cocona/Hosting/CoconaHostBuilderExtensions.cs
+++ b/src/Cocona/Hosting/CoconaHostBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Hosting
                 .ConfigureAppConfiguration(config => { })
                 .ConfigureServices(services =>
                 {
-                    services.AddCoconaCore(args ?? GetCommandLineArguments());
+                    services.AddCoconaCore(args);
                     services.AddCoconaShellCompletion();
 
                     services.AddHostedService<CoconaHostedService>();
@@ -64,12 +64,5 @@ namespace Microsoft.Extensions.Hosting
                 });
         }
 
-        private static string[] GetCommandLineArguments()
-        {
-            var args = System.Environment.GetCommandLineArgs();
-            return args.Any()
-                ? args.Skip(1).ToArray() // args[0] is the path to executable binary.
-                : Array.Empty<string>();
-        }
     }
 }

--- a/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
+++ b/src/Cocona/Hosting/CoconaServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public static class CoconaServiceCollectionExtensions
     {
-        internal static IServiceCollection AddCoconaCore(this IServiceCollection services, string[] args)
+        internal static IServiceCollection AddCoconaCore(this IServiceCollection services, string[]? args)
         {
 #if COCONA_LITE
             services.AddSingleton<ICoconaInstanceActivator>(_ => new CoconaLiteInstanceActivator());
@@ -73,8 +73,9 @@ namespace Microsoft.Extensions.Hosting
                     options.EnableShellCompletionSupport
                 );
             });
+            services.TryAddSingleton<ICoconaEnvironmentProvider, DefaultCoconaEnvironmentProvider>();
             services.TryAddSingleton<ICoconaCommandLineArgumentProvider>(serviceProvider =>
-                new CoconaCommandLineArgumentProvider(args));
+                new CoconaCommandLineArgumentProvider(args ?? serviceProvider.GetRequiredService<ICoconaEnvironmentProvider>().GetCommandLineArgs()));
             services.TryAddSingleton<ICoconaCommandDispatcherPipelineBuilder, CoconaCommandDispatcherPipelineBuilder>();
             services.TryAddSingleton<ICoconaAppContextAccessor, CoconaAppContextAccessor>();
             services.TryAddSingleton<ICoconaApplicationMetadataProvider, CoconaApplicationMetadataProvider>();


### PR DESCRIPTION
Moves getting command line args into the DI chain when args are not passed down by the developer,

This allows the `DefaultCoconaEnvironmentProvider` to potentially be replaced for the purpose of mocking inputs for integration testing.

fixes #71 