### PR TITLE
Chaining AddCommand

### DIFF
--- a/Cocona.sln
+++ b/Cocona.sln
@@ -102,6 +102,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{72
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoconaSample.MinimalApi.AddCommands", "samples\MinimalApi.AddCommands\CoconaSample.MinimalApi.AddCommands.csproj", "{48B3DD2C-AF52-4E9D-8F1E-72266B557C40}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -244,6 +246,10 @@ Global
 		{7A178909-623C-4788-ADD4-9437091128BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A178909-623C-4788-ADD4-9437091128BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A178909-623C-4788-ADD4-9437091128BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48B3DD2C-AF52-4E9D-8F1E-72266B557C40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48B3DD2C-AF52-4E9D-8F1E-72266B557C40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48B3DD2C-AF52-4E9D-8F1E-72266B557C40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48B3DD2C-AF52-4E9D-8F1E-72266B557C40}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -283,6 +289,7 @@ Global
 		{51E42619-D33A-4046-A80D-A979591C19D3} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{7A178909-623C-4788-ADD4-9437091128BA} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{72AC9837-3045-4692-909B-1BD04F408B48} = {09F6C99E-D874-4C82-90AA-A37E5BE707C4}
+		{48B3DD2C-AF52-4E9D-8F1E-72266B557C40} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DBA26EF-235B-4656-A5DD-00C266A42735}

--- a/samples/MinimalApi.AddCommands/CoconaSample.MinimalApi.AddCommands.csproj
+++ b/samples/MinimalApi.AddCommands/CoconaSample.MinimalApi.AddCommands.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cocona\Cocona.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MinimalApi.AddCommands/Program.cs
+++ b/samples/MinimalApi.AddCommands/Program.cs
@@ -1,0 +1,12 @@
+using Cocona;
+CoconaApp
+.CreateBuilder()
+.Build()
+.AddCommands
+(
+    ("hello", (string name) => Console.WriteLine($"Hello {name}!")),
+    ("bye", (string name) => Console.WriteLine($"Bye {name}!"))
+)
+.AddCommands(("foo", () => Console.WriteLine("Bar")))
+.AsCoconaApp()
+.Run();

--- a/src/Cocona.Core/Builder/CoconaCommandsBuilder.cs
+++ b/src/Cocona.Core/Builder/CoconaCommandsBuilder.cs
@@ -167,11 +167,11 @@ namespace Cocona
         /// <param name="builder"></param>
         /// <param name="commandBody"></param>
         /// <returns></returns>
-        public static ICoconaCommandsBuilder AddCommands(this ICoconaCommandsBuilder builder, params Delegate[] commandBodies)
+        public static ICoconaCommandsBuilder AddCommands(this ICoconaCommandsBuilder builder, params (string, Delegate)[] commandBodies)
         {
-            foreach (var commandBody in commandBodies)
+            foreach (var (name, commandBody) in commandBodies)
             {
-                builder.AddCommand(commandBody);
+                builder.AddCommand(name, commandBody);
             }
             return builder;
         }

--- a/src/Cocona.Core/Builder/CoconaCommandsBuilder.cs
+++ b/src/Cocona.Core/Builder/CoconaCommandsBuilder.cs
@@ -160,6 +160,19 @@ namespace Cocona
             return new CommandConventionBuilder(conventions).FromBuilder().WithMetadata(new PrimaryCommandAttribute());
         }
 
+        
+        /// <summary>
+        /// Adds a primary command definition delegate to the builder and return the builder.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="commandBody"></param>
+        /// <returns></returns>
+        public static ICoconaCommandsBuilder AddCommand(this ICoconaCommandsBuilder builder, Delegate commandBody)
+        {
+           builder.AddCommand(commandBody);
+           return builder;
+        }
+
         /// <summary>
         /// Adds a command definition delegate to the builder.
         /// </summary>

--- a/src/Cocona.Core/Builder/CoconaCommandsBuilder.cs
+++ b/src/Cocona.Core/Builder/CoconaCommandsBuilder.cs
@@ -160,17 +160,20 @@ namespace Cocona
             return new CommandConventionBuilder(conventions).FromBuilder().WithMetadata(new PrimaryCommandAttribute());
         }
 
-        
+
         /// <summary>
         /// Adds a primary command definition delegate to the builder and return the builder.
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="commandBody"></param>
         /// <returns></returns>
-        public static ICoconaCommandsBuilder AddCommand(this ICoconaCommandsBuilder builder, Delegate commandBody)
+        public static ICoconaCommandsBuilder AddCommands(this ICoconaCommandsBuilder builder, params Delegate[] commandBodies)
         {
-           builder.AddCommand(commandBody);
-           return builder;
+            foreach (var commandBody in commandBodies)
+            {
+                builder.AddCommand(commandBody);
+            }
+            return builder;
         }
 
         /// <summary>

--- a/src/Cocona/CoconaAppExtensions.cs
+++ b/src/Cocona/CoconaAppExtensions.cs
@@ -1,0 +1,10 @@
+﻿using Cocona.Builder;
+
+namespace Cocona
+{
+    public static class CoconaAppExtensions 
+    {
+        public static CoconaApp AsCoconaApp(this ICoconaCommandsBuilder coconaCommandsBuilder) =>
+            (CoconaApp)coconaCommandsBuilder;
+    }
+}

--- a/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
+++ b/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
@@ -183,10 +183,28 @@ namespace Cocona.Test.Builder
         { }
 
         [Fact]
-        public void AddCommand_Chained()
+        public void AddCommands_Chained()
         {
             var builder = new CoconaCommandsBuilder();
-            builder.AddCommand(() => { }).AddCommand(() => { });
+            builder.AddCommands(() => { }).AddCommands(() => { });
+
+            var built = builder.Build();
+            built.Should().HaveCount(2);
+            built[0].Should().BeOfType<DelegateCommandData>();
+            built[0].Metadata.Should().HaveCount(2);
+            built[0].Metadata[0].Should().BeOfType<CommandFromBuilderMetadata>();
+            built[0].Metadata[1].Should().BeOfType<PrimaryCommandAttribute>();
+            built[1].Should().BeOfType<DelegateCommandData>();
+            built[1].Metadata.Should().HaveCount(2);
+            built[1].Metadata[0].Should().BeOfType<CommandFromBuilderMetadata>();
+            built[1].Metadata[1].Should().BeOfType<PrimaryCommandAttribute>();
+        }
+
+        [Fact]
+        public void AddCommands_Multiparams()
+        {
+            var builder = new CoconaCommandsBuilder();
+            builder.AddCommands(() => { }, () => { });
 
             var built = builder.Build();
             built.Should().HaveCount(2);

--- a/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
+++ b/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
@@ -186,7 +186,7 @@ namespace Cocona.Test.Builder
         public void AddCommands_Chained()
         {
             var builder = new CoconaCommandsBuilder();
-            builder.AddCommands(() => { }).AddCommands(() => { });
+            builder.AddCommands(("1", () => { })).AddCommands(("2", () => { }));
 
             var built = builder.Build();
             built.Should().HaveCount(2);
@@ -204,7 +204,10 @@ namespace Cocona.Test.Builder
         public void AddCommands_Multiparams()
         {
             var builder = new CoconaCommandsBuilder();
-            builder.AddCommands(() => { }, () => { });
+            builder.AddCommands(
+                ("1", () => { }), 
+                ("2", () => { })
+            );
 
             var built = builder.Build();
             built.Should().HaveCount(2);

--- a/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
+++ b/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
@@ -181,5 +181,23 @@ namespace Cocona.Test.Builder
         }
         class UseFilter_Filter3 : IFilterMetadata
         { }
+
+        [Fact]
+        public void AddCommand_Chained()
+        {
+            var builder = new CoconaCommandsBuilder();
+            builder.AddCommand(() => { }).AddCommand(() => { });
+
+            var built = builder.Build();
+            built.Should().HaveCount(2);
+            built[0].Should().BeOfType<DelegateCommandData>();
+            built[0].Metadata.Should().HaveCount(2);
+            built[0].Metadata[0].Should().BeOfType<CommandFromBuilderMetadata>();
+            built[0].Metadata[1].Should().BeOfType<PrimaryCommandAttribute>();
+            built[1].Should().BeOfType<DelegateCommandData>();
+            built[1].Metadata.Should().HaveCount(2);
+            built[1].Metadata[0].Should().BeOfType<CommandFromBuilderMetadata>();
+            built[1].Metadata[1].Should().BeOfType<PrimaryCommandAttribute>();
+        }
     }
 }


### PR DESCRIPTION
Maybe this is possible but I just could not figure out how. But the structure I have in my real program is this:

```
using Cocona;
using ping_cli;
var app = CoconaApp.CreateBuilder().Build();
app.AddCommand("set-config", Commands.SetConfig());
app.AddCommand("get-config", Commands.GetConfig());
app.AddCommand("ping", Commands.Ping());
app.AddCommand("settle", Commands.SettlePaymentOrder());
app.Run();
```

And I would like to have it chained:

```
using Cocona;
using ping_cli;
CoconaApp.CreateBuilder().Build();
app.AddCommand("set-config", Commands.SetConfig());
app.AddCommand("get-config", Commands.GetConfig());
app.AddCommand("ping", Commands.Ping());
app.AddCommand("settle", Commands.SettlePaymentOrder());
app.Run();
```