### PR TITLE
Remove net5.0 support

### DIFF
--- a/src/Cocona.Core/Cocona.Core.csproj
+++ b/src/Cocona.Core/Cocona.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Cocona</RootNamespace>
 
     <nullable>enable</nullable>

--- a/src/Cocona.Lite/Cocona.Lite.csproj
+++ b/src/Cocona.Lite/Cocona.Lite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Cocona</RootNamespace>
 
     <nullable>enable</nullable>

--- a/src/Cocona/Cocona.csproj
+++ b/src/Cocona/Cocona.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <nullable>enable</nullable>
     <WarningsAsErrors>RS0030</WarningsAsErrors>
     <NoWarn>$(NoWarn);1701;1702;1591</NoWarn>


### PR DESCRIPTION
I opened a new pull request but it seems failed because net5.0 reached end-of-life and Cocona supports net5.0 yet.

If this pull request's azure pipelines also fails, I'll close this pull request.