### PR TITLE
Correct shellcheck warning

### DIFF
--- a/src/Cocona.Core/ShellCompletion/Generators/Resources/bash_common.sh
+++ b/src/Cocona.Core/ShellCompletion/Generators/Resources/bash_common.sh
@@ -68,7 +68,7 @@ __cocona_APPNAMEPLACEHOLDER_completion_get_argument_index() {
         fi
     done
 
-    return $index
+    return "$index"
 }
 
 __cocona_APPNAMEPLACEHOLDER_completion_index_of() {
@@ -77,7 +77,7 @@ __cocona_APPNAMEPLACEHOLDER_completion_index_of() {
     for i in "${@:2}"
     do
         if [[ "$i" == "$value" ]]; then
-            return $index
+            return "$index"
         fi
         ((index++))
     done


### PR DESCRIPTION
Currently, the build on *master* branch fails because of shellcheck. So this pull request resolves https://www.shellcheck.net/wiki/SC2086.

https://dev.azure.com/misuzilla/Cocona/_build/results?buildId=1606&view=logs&jobId=bfe74a74-420d-51e7-ad1a-e33e708cc1f4&j=bfe74a74-420d-51e7-ad1a-e33e708cc1f4&t=e1878e94-60b4-5b5a-22a1-1f14a660a9aa