### PR TITLE
Add net7 SDK in pipeline

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -24,6 +24,10 @@ jobs:
       inputs:
         packageType: 'sdk'
         version: 3.1.x
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        version: 7.x
     - script: dotnet restore
       displayName: dotnet restore
 

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -27,7 +27,7 @@ jobs:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: 7.x
+        version: 7.0.x
     - script: dotnet restore
       displayName: dotnet restore
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
         dotnet-version: |
           3.1.x
           6.0.x
+          7.0.x
 
     # Build
     - run: dotnet restore


### PR DESCRIPTION
The PR here #88 is blocked by pipeline not installing net 7.0 sdk. Simple add a task in the azure pipeline to install it. 