### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ Cocona can use attributes to validate options and arguments. It is similar to AS
 .NET BCL (`System.ComponentModel.DataAnnotations`) has some pre-defined attributes:
 
 - `RangeAttribute`
-- `MaxLangeAttribute`
+- `MaxLengthAttribute`
 - `MinLengthAttribute`
 - ...
 


### PR DESCRIPTION
I could not find anything about a MaxLangeAttribute so I assume the MaxLengthAttribute was meant here.