### PR TITLE
CoconaValueConverter to support FileInfo and DirectoryInfo

### DIFF
--- a/src/Cocona.Core/Command/Binder/CoconaValueConverter.cs
+++ b/src/Cocona.Core/Command/Binder/CoconaValueConverter.cs
@@ -22,6 +22,14 @@ public class CoconaValueConverter : ICoconaValueConverter
         {
             return value;
         }
+        else if (t == typeof(FileInfo))
+        {
+            return value is null ? null : new FileInfo(value);
+        }
+        else if (t == typeof(DirectoryInfo))
+        {
+            return value is null ? null : new DirectoryInfo(value);
+        }
 
         return TypeDescriptor.GetConverter(t).ConvertFrom(value);
     }

--- a/test/Cocona.Test/Command/ParameterBinder/ValueConverterTest.cs
+++ b/test/Cocona.Test/Command/ParameterBinder/ValueConverterTest.cs
@@ -4,6 +4,32 @@ namespace Cocona.Test.Command.ParameterBinder;
 
 public class ValueConverterTest
 {
+    internal class FileInfoComparer : IEqualityComparer<FileInfo>
+    {
+        public bool Equals(FileInfo? x, FileInfo? y)
+        {
+            return x?.Name == y?.Name;
+        }
+
+        public int GetHashCode(FileInfo obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+
+    internal class DirectoryInfoComparer : IEqualityComparer<DirectoryInfo>
+    {
+        public bool Equals(DirectoryInfo? x, DirectoryInfo? y)
+        {
+            return x?.Name == y?.Name;
+        }
+
+        public int GetHashCode(DirectoryInfo obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+
     [Fact]
     public void CanNotConvertType_Int32()
     {
@@ -38,5 +64,31 @@ public class ValueConverterTest
     public void Boolean_Int32()
     {
         new CoconaValueConverter().ConvertTo(typeof(int), "12345").Should().Be(12345);
+    }
+
+    [Fact]
+    public void DirectoryInfo_Null()
+    {
+        new CoconaValueConverter().ConvertTo(typeof(FileInfo), null).Should().Be(null);
+    }
+
+    [Fact]
+    public void DirectoryInfo_String()
+    {
+        new CoconaValueConverter().ConvertTo(typeof(DirectoryInfo), "somedirname").Should()
+            .Be(new DirectoryInfo("somedirname"), new DirectoryInfoComparer());
+    }
+
+    [Fact]
+    public void FileInfo_Null()
+    {
+        new CoconaValueConverter().ConvertTo(typeof(FileInfo), null).Should().Be(null);
+    }
+
+    [Fact]
+    public void FileInfo_String()
+    {
+        new CoconaValueConverter().ConvertTo(typeof(FileInfo), "somefilename").Should()
+            .Be(new FileInfo("somefilename"), new FileInfoComparer());
     }
 }


### PR DESCRIPTION
System.CommandLine supports FileInfo and DirectoryInfo as arguments. It seems to be useful and this is a feature I'm missing in Cocona.

I'm also was considering to make a ICoconaValueConverter<T> interface and look up for converter in DI container but it seems to be too much for the change.