### PR TITLE
Fix a stack overflow in non-writable working directories

### DIFF
--- a/src/Cocona/Builder/Internal/BootstrapHostBuilder.cs
+++ b/src/Cocona/Builder/Internal/BootstrapHostBuilder.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -45,7 +46,8 @@ internal class BootstrapHostBuilder : IHostBuilder
             HostingEnvironment = new HostEnvironment(hostConfiguration[HostDefaults.ApplicationKey]!, contentRootPath, new PhysicalFileProvider(contentRootPath), hostConfiguration[HostDefaults.EnvironmentKey] ?? Environments.Production)
         };
 
-        configuration.SetBasePath(hostBuilderContext.HostingEnvironment.ContentRootPath);
+        var appLocation = Assembly.GetCallingAssembly().Location;
+        configuration.SetBasePath(Path.GetDirectoryName(appLocation)!);
         configuration.AddConfiguration(hostConfiguration, true);
         foreach (var action in _configureAppConfigs)
         {


### PR DESCRIPTION
Fixes #128. By using the running application's directory as the base path, the package won't access possibly non-writable working directories.

https://github.com/mayuki/Cocona/assets/69001314/519c19c2-2dc9-4b3f-b6e5-ef3496a8eaea