### PR TITLE
Adding support for `HostApplicationBuilder`

### DIFF
--- a/Cocona.sln
+++ b/Cocona.sln
@@ -102,6 +102,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{72
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.Advanced.GenericHost.HostApplicationBuilder", "samples\CoconaSample.Advanced.GenericHost.HostApplicationBuilder\CoconaSample.Advanced.GenericHost.HostApplicationBuilder.csproj", "{3ED634C5-7034-4F13-9FD1-BB9717E17791}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -244,6 +246,10 @@ Global
 		{7A178909-623C-4788-ADD4-9437091128BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A178909-623C-4788-ADD4-9437091128BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A178909-623C-4788-ADD4-9437091128BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3ED634C5-7034-4F13-9FD1-BB9717E17791}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ED634C5-7034-4F13-9FD1-BB9717E17791}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3ED634C5-7034-4F13-9FD1-BB9717E17791}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3ED634C5-7034-4F13-9FD1-BB9717E17791}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -283,6 +289,7 @@ Global
 		{51E42619-D33A-4046-A80D-A979591C19D3} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{7A178909-623C-4788-ADD4-9437091128BA} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{72AC9837-3045-4692-909B-1BD04F408B48} = {09F6C99E-D874-4C82-90AA-A37E5BE707C4}
+		{3ED634C5-7034-4F13-9FD1-BB9717E17791} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DBA26EF-235B-4656-A5DD-00C266A42735}

--- a/samples/CoconaSample.Advanced.GenericHost.HostApplicationBuilder/CoconaSample.Advanced.GenericHost.HostApplicationBuilder.csproj
+++ b/samples/CoconaSample.Advanced.GenericHost.HostApplicationBuilder/CoconaSample.Advanced.GenericHost.HostApplicationBuilder.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+   <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cocona\Cocona.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/CoconaSample.Advanced.GenericHost.HostApplicationBuilder/Program.cs
+++ b/samples/CoconaSample.Advanced.GenericHost.HostApplicationBuilder/Program.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder();
+
+builder.ConfigureCocona(args, new[] { typeof(Commands) });
+                
+var host = builder.Build();
+
+await host.RunAsync();
+
+public class Commands
+{
+    public void Hello() => Console.WriteLine($"Hello Konnichiwa!");
+}

--- a/src/Cocona/Hosting/CoconaHostApplicationBuilderExtensions.cs
+++ b/src/Cocona/Hosting/CoconaHostApplicationBuilderExtensions.cs
@@ -1,0 +1,62 @@
+using Cocona.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Cocona.Builder.Internal;
+using Cocona;
+using Cocona.Builder;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Hosting;
+
+public static class CoconaHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds and configures a Cocona application.
+    /// </summary>
+    /// <param name="hostBuilder"></param>
+    /// <param name="args"></param>
+    /// <param name="types"></param>
+    /// <param name="methods"></param>
+    /// <returns></returns>
+    public static HostApplicationBuilder ConfigureCocona(
+        this HostApplicationBuilder hostBuilder, 
+        string[]? args, 
+        IEnumerable<Type> types, 
+        IEnumerable<Delegate>? methods = null)
+            => hostBuilder.ConfigureCocona(args, (app) =>
+            {
+                app.AddCommands(types);
+
+                foreach (var method in methods ?? [])
+                {
+                    app.AddCommand(method);
+                }
+            });
+
+    /// <summary>
+    /// Adds and configures a Cocona application.
+    /// </summary>
+    /// <param name="hostBuilder"></param>
+    /// <param name="args"></param>
+    /// <param name="configureApplication"></param>
+    /// <returns></returns>
+    public static HostApplicationBuilder ConfigureCocona(
+        this HostApplicationBuilder hostBuilder, 
+        string[]? args, 
+        Action<ICoconaCommandsBuilder>? configureApplication = null)
+    {
+        hostBuilder.Services.AddCoconaCore(args);
+        hostBuilder.Services.AddCoconaShellCompletion();
+
+        hostBuilder.Services.AddHostedService<CoconaHostedService>();
+
+        hostBuilder.Services.Configure<CoconaAppHostOptions>(options =>
+        {
+            options.ConfigureApplication = app =>
+            {
+                configureApplication?.Invoke(app);
+            };
+        });
+        return hostBuilder;
+    }
+
+}


### PR DESCRIPTION
Hey!
It seems that Microsoft is pushing towards a more linear bootstrapping process for their application host. Hence, they are pushing towards the usage of their `HostApplicationBuilder`. This pull request has a relatively simple reimplementation of the `IHostBuilder` extensions methods to use the `HostApplicationBuilder`. I've also added a sample following the lines of the `GenericHost` sample you've got.