### PR TITLE
Enable interface-wide command registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,11 @@ app.Run();
 You can add (classic) Class-based style commands with the `AddCommands<T>` method.
 
 ```csharp
+// Adds a MyCommand class
 app.AddCommands<MyCommand>();
+
+// Adds all classes inheriting from the ICommands interface
+app.AddCommands<ICommands>();
 ```
 
 #### Public method as a command (Class-based style)

--- a/src/Cocona.Core/Builder/CoconaCommandsBuilderExtensions.cs
+++ b/src/Cocona.Core/Builder/CoconaCommandsBuilderExtensions.cs
@@ -144,8 +144,21 @@ public static class CoconaCommandsBuilderExtensions
         ThrowHelper.ThrowIfNull(commandType);
 
         var conventions = new List<Action<ICommandBuilder>>();
-        builder.Add(new TypeCommandDataSource(commandType, conventions, builder.GetFilters().ToArray()));
+        if (!commandType.IsInterface)
+        {
+            builder.Add(new TypeCommandDataSource(commandType, conventions, builder.GetFilters().ToArray()));
+            return new CommandTypeConventionBuilder(conventions);
+        }
+        
+        var commandTypes = commandType.Assembly.DefinedTypes
+            .Where(x => x is { IsAbstract: false, IsInterface: false } && commandType.IsAssignableFrom(x))
+            .Select(x => x.AsType());
 
+        foreach (var type in commandTypes)
+        {
+            builder.Add(new TypeCommandDataSource(type, conventions, builder.GetFilters().ToArray()));
+        }
+        
         return new CommandTypeConventionBuilder(conventions);
     }
 

--- a/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
+++ b/test/Cocona.Test/Builder/CoconaCommandBuilderTest.cs
@@ -150,6 +150,27 @@ public class CoconaCommandBuilderTest
     {
         public void Hello() => Console.WriteLine("Hello");
     }
+    
+    [Fact]
+    public void AddCommands_Interface()
+    {
+        var builder = new CoconaCommandsBuilder();
+        builder.AddCommands<ICommands>();
+
+        var built = builder.Build();
+        built.Should().HaveCount(2);
+        built[0].Should().BeOfType<TypeCommandData>().Subject.Type.Should().Be<InterfaceCommands>();
+        built[1].Should().BeOfType<TypeCommandData>().Subject.Type.Should().Be<MoreInterfaceCommands>();
+    }
+    
+    interface ICommands
+    { }
+    
+    class InterfaceCommands : ICommands
+    { }
+    
+    class MoreInterfaceCommands : ICommands
+    { }
 
     [Fact]
     public void Filter_Builder_UseFilter()


### PR DESCRIPTION
This PR enables registering all command classes inheriting from a shared interface.

```csharp
// Rather than adding all command classes individually...
app.AddCommands<MyCommand1>();
app.AddCommands<MyCommand2>();
app.AddCommands<MyCommand3>();

// ...you can add an interface the command classes inherit from!
interface ICommands { }
class MyCommand1 : ICommands { ... }
class MyCommand2 : ICommands { ... }
class MyCommand3 : ICommands { ... }

app.AddCommands<ICommands>();
```

This could also be potentially useful for command registration branching, where certain requirements need to be met for a specific set of commands to work:

```csharp
// For debugging
if (Debugger.IsAttached)
{
    app.AddCommands<IDebugCommands>();
}

// For Windows-specific features of a cross-platform tool
if (OperatingSystem.IsWindows())
{
    app.AddCommands<IWindowsCommands>();
}
```