### PR TITLE
#126: Ammended `Getting Started-Try to run` section because applicati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ class Program
 
 ### Try to run!
 ```sh
-$ dotnet run
+$ dotnet run -- --help
 Usage: ConsoleAppSample [--name <String>]
 
 Options:


### PR DESCRIPTION
Fixed the getting started section of the docs because just starting the app with `dotnet run` as they show, does not show the usage text, it shows an error. 