### PR TITLE
Allow creation of custom List/Enumerable wrappers

### DIFF
--- a/Cocona.sln
+++ b/Cocona.sln
@@ -104,6 +104,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.Advanced.GenericHost.HostApplicationBuilder", "samples\CoconaSample.Advanced.GenericHost.HostApplicationBuilder\CoconaSample.Advanced.GenericHost.HostApplicationBuilder.csproj", "{3ED634C5-7034-4F13-9FD1-BB9717E17791}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoconaSample.InAction.WrappedArrayParameterSet", "samples\InAction.WrappedArrayParameterSet\CoconaSample.InAction.WrappedArrayParameterSet.csproj", "{C578D0AA-E07F-4F39-357C-40E6FF553676}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -250,6 +252,10 @@ Global
 		{3ED634C5-7034-4F13-9FD1-BB9717E17791}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3ED634C5-7034-4F13-9FD1-BB9717E17791}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3ED634C5-7034-4F13-9FD1-BB9717E17791}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C578D0AA-E07F-4F39-357C-40E6FF553676}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C578D0AA-E07F-4F39-357C-40E6FF553676}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C578D0AA-E07F-4F39-357C-40E6FF553676}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C578D0AA-E07F-4F39-357C-40E6FF553676}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -290,6 +296,7 @@ Global
 		{7A178909-623C-4788-ADD4-9437091128BA} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 		{72AC9837-3045-4692-909B-1BD04F408B48} = {09F6C99E-D874-4C82-90AA-A37E5BE707C4}
 		{3ED634C5-7034-4F13-9FD1-BB9717E17791} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
+		{C578D0AA-E07F-4F39-357C-40E6FF553676} = {26F0BA96-C75C-4BDF-A1CC-3A9F58A16D9E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DBA26EF-235B-4656-A5DD-00C266A42735}

--- a/samples/InAction.WrappedArrayParameterSet/CoconaSample.InAction.WrappedArrayParameterSet.csproj
+++ b/samples/InAction.WrappedArrayParameterSet/CoconaSample.InAction.WrappedArrayParameterSet.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cocona\Cocona.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/InAction.WrappedArrayParameterSet/Program.cs
+++ b/samples/InAction.WrappedArrayParameterSet/Program.cs
@@ -1,0 +1,79 @@
+using System.Collections;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Cocona;
+
+namespace CoconaSample.InAction.WrappedArrayParameterSet;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        CoconaApp.Run<Program>(args);
+    }
+
+    /// <summary>
+    /// Define a set of Options and Arguments that are common to multiple commands.
+    /// </summary>
+    public record CommonParameters(
+        [Option('t', Description = "Specifies the remote host to connect.")]
+        string Host,
+        [Option('i', Description = "Items to process")]
+        WrappedArray<WrappedItem> Items
+    ) : ICommandParameterSet;
+
+    public class WrappedArray<T> : IEnumerable<T>
+    {
+        private readonly T[] _items;
+
+        public WrappedArray(T[] items) {
+            _items = items;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return ((IEnumerable<T>)_items).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+    }
+
+    [TypeConverter(typeof(WrappedItemConverter))]
+    public record WrappedItem(int Index, string First3Letters, string Rest);
+
+    public class WrappedItemConverter : TypeConverter
+    {
+        private static int _counter;
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string)) return true;
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string s)
+            {
+                return new WrappedItem(_counter++, s.Substring(0, 3), s.Substring(3));
+            }
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+
+    public void Add(CommonParameters commonParams, [Argument] string from, [Argument] string to)
+    {
+        Console.WriteLine($"Add: {commonParams} {string.Join(", ", commonParams.Items)}");
+        Console.WriteLine($"{from} -> {to}");
+    }
+
+    public void Update(CommonParameters commonParams, [Option('r', Description = "Traverse recursively to perform.")] bool recursive, [Argument] string path)
+    {
+        Console.WriteLine($"Update: {commonParams} {string.Join(", ", commonParams.Items)}");
+        Console.WriteLine($"{path}{(recursive ? " (Recursive)" : "")}");
+    }
+}

--- a/samples/InAction.WrappedArrayParameterSet/Properties/launchSettings.json
+++ b/samples/InAction.WrappedArrayParameterSet/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "CoconaSample.InAction.WrappedArrayParameterSet": {
+      "commandName": "Project",
+      "commandLineArgs": "Add -t test -i first -i second from to"
+    }
+  }
+}


### PR DESCRIPTION
while I was working with Cocona I ran into an issue where I wanted some extra behaviour on a list of items given on the command line, I found no other way of doing it than with an intermediate holding list and then a lazy property that on initial read would load my wrapper.

I think this is a better solution, where when a constructor exists for the wrapping type that accepts an IEnumerable of the list type Cocona calls that constructor.